### PR TITLE
Change how to load Gemfile.local

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in lightchef.gemspec
 gemspec
 
-gemfile_local = File.expand_path('../Gemfile.local', __FILE__)
-if File.exist?(gemfile_local)
-  load gemfile_local
-end
+path = Pathname.new("Gemfile.local")
+eval(path.read) if path.exist?
 
 group :test do
   if RUBY_PLATFORM.include?('darwin')


### PR DESCRIPTION
なぜかよくわからないけど、以下のエラーが出るので、以前 atria ではうまくいったよな、と思って、[altria の Gemfile](https://github.com/r7kamura/altria/blob/master/Gemfile#L44) からパクってみました。

```
$ bundle install
/Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/2.1.0/rubygems/dependency.rb:298:in `to_specs': Could not find 'specinfra' (>= 0) among 235 total gem(s) (Gem::LoadError)
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/2.1.0/rubygems/dependency.rb:309:in `to_spec'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_gem.rb:53:in `gem'
       /Users/mizzy/src/github.com/ryotarai/lightchef/Gemfile.local:1:in `<top (required)>'
       /Users/mizzy/src/github.com/ryotarai/lightchef/Gemfile:8:in `load'
       /Users/mizzy/src/github.com/ryotarai/lightchef/Gemfile:8:in `eval_gemfile'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/lib/bundler/dsl.rb:30:in `instance_eval'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/lib/bundler/dsl.rb:30:in `eval_gemfile'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/lib/bundler/dsl.rb:9:in `evaluate'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/lib/bundler/definition.rb:26:in `build'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/lib/bundler.rb:152:in `definition'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/lib/bundler/cli.rb:253:in `install'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/lib/bundler/vendor/thor/command.rb:27:in `run'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/lib/bundler/vendor/thor/invocation.rb:121:in `invoke_command'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/lib/bundler/vendor/thor.rb:363:in `dispatch'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/lib/bundler/vendor/thor/base.rb:440:in `start'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/lib/bundler/cli.rb:10:in `start'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/bin/bundle:20:in `block in <top (required)>'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/lib/bundler/friendly_errors.rb:5:in `with_friendly_errors'
       /Users/mizzy/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.5.3/bin/bundle:20:in `<top (required)>'
       /Users/mizzy/.rbenv/versions/2.1.1/bin/bundle:23:in `load'
       /Users/mizzy/.rbenv/versions/2.1.1/bin/bundle:23:in `<main>'
```
