### PR TITLE
Don't call Specinfra.backend directory. Call Specinfra::Runner

### DIFF
--- a/itamae.gemspec
+++ b/itamae.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "thor"
-  spec.add_runtime_dependency "specinfra", "2.0.0.beta30"
+  spec.add_runtime_dependency "specinfra", "2.0.0.beta32"
   spec.add_runtime_dependency "hashie"
 
   # TODO: move to specinfra

--- a/lib/itamae/specinfra.rb
+++ b/lib/itamae/specinfra.rb
@@ -26,7 +26,7 @@ module Itamae
   private
   def self.create_backend(type)
     Specinfra.configuration.backend = type
-    Itamae.backend = Specinfra.backend
+    Itamae.backend = Specinfra::Runner
   end
 
   module SpecinfraHelpers


### PR DESCRIPTION
Specinfra v2.0.0beta32 からは、内部の method_missing をなるべく減らすために、Specinfra::Runner 内で諸々の処理を行うようにして、直接 Specinfra.backend は呼び出さないようにする方式に変えたので、それに合わせてこちらも修正しました。
