### PR TITLE
Fix remote_file_spec.rb

### DIFF
--- a/spec/unit/lib/itamae/resource/remote_file_spec.rb
+++ b/spec/unit/lib/itamae/resource/remote_file_spec.rb
@@ -27,6 +27,7 @@ module Itamae
         expect(subject).to receive(:run_specinfra).with(:check_file_is_file, "/path/to/dst").and_return(true)
         expect(subject).to receive(:run_command).with(["cp", "/path/to/dst", "/path/to/dst.bak"])
         expect(subject).to receive(:run_command).with(["mv", %r{/tmp/itamae/[\d\.]+}, "/path/to/dst"])
+        subject.pre_action
         subject.create_action
       end
     end


### PR DESCRIPTION
If pre_action is not executed, @temppath is not set and spec fails.
