### PR TITLE
Fix error message when recipe not found

### DIFF
--- a/lib/itamae/recipe.rb
+++ b/lib/itamae/recipe.rb
@@ -56,7 +56,7 @@ module Itamae
       target = candidate_paths.find {|path| File.exist?(path) }
 
       unless target
-        raise NotFoundError, "File not found. (#{target})"
+        raise NotFoundError, "Recipe not found. (#{recipe})"
       end
 
       if runner.children.find_recipe_by_path(target)


### PR DESCRIPTION
When recipe not found, target is nil. So I've changed to display recipe name instead of target.
