### PR TITLE
Add vagrant option to cli

### DIFF
--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -33,6 +33,7 @@ module Itamae
     option :key, type: :string, aliases: ['-i']
     option :port, type: :numeric, aliases: ['-p']
     option :ohai, type: :boolean, default: false
+    option :vagrant, type: :boolean, default: false
     def ssh(*recipe_files)
       if recipe_files.empty?
         raise "Please specify recipe files."

--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -49,6 +49,13 @@ module Itamae
           opts[:user] = options[:user] || Etc.getlogin
           opts[:keys] = [options[:key]] if options[:key]
           opts[:port] = options[:port] if options[:port]
+
+          if options[:vagrant]
+            config = Tempfile.new('', Dir.tmpdir)
+            `vagrant ssh-config #{opts[:host]} > #{config.path}`
+            opts.merge!(Net::SSH::Config.for(opts[:host], [config.path]))
+            opts[:host] = opts.delete(:host_name)
+          end
         end
 
         Backend.instance.set_type(type, opts)


### PR DESCRIPTION
With this fix, you can access Vagrant VM easily like this.

```
$ itamae ssh --host=vagrant-vm-name --vagrant recipe.rb
```

If you don't need this kind of feature, please close this.
