### PR TITLE
Change how to handle tempfile

### DIFF
--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -12,17 +12,21 @@ module Itamae
       define_attribute :group, type: String
 
       def pre_action
-        src = if content_file
-                content_file
-              else
-                Tempfile.open('itamae') do |f|
+        begin
+          src = if content_file
+                  content_file
+                else
+                  f = Tempfile.open('itamae')
                   f.write(content)
+                  f.close
                   f.path
                 end
-              end
 
-        @temppath = ::File.join(runner.tmpdir, Time.now.to_f.to_s)
-        send_file(src, @temppath)
+          @temppath = ::File.join(runner.tmpdir, Time.now.to_f.to_s)
+          send_file(src, @temppath)
+        ensure
+          f.unlink
+        end
 
         case @current_action
         when :create


### PR DESCRIPTION
Tempfile is removed when exiting the block. So occasionally tempfile is removed before send_file method.

So quit to use the block with tempfile and unlink file inside ensure block.
