### PR TITLE
Refactor resources

### DIFF
--- a/lib/itamae/notification.rb
+++ b/lib/itamae/notification.rb
@@ -1,7 +1,7 @@
 require 'itamae'
 
 module Itamae
-  class Notification < Struct.new(:runner, :defined_in_resource, :action, :target_resource_desc, :timing)
+  class Notification < Struct.new(:defined_in_resource, :action, :target_resource_desc, :timing)
     def resource
       runner.children.find_resource_by_description(target_resource_desc)
     end
@@ -12,6 +12,10 @@ module Itamae
 
     def action_resource
       resource
+    end
+
+    def runner
+      defined_in_resource.recipe.runner
     end
   end
 

--- a/lib/itamae/resource/directory.rb
+++ b/lib/itamae/resource/directory.rb
@@ -17,13 +17,13 @@ module Itamae
       end
 
       def set_current_attributes
-        exist = run_specinfra(:check_file_is_directory, path)
+        exist = run_specinfra(:check_file_is_directory, attributes.path)
         current.exist = exist
 
         if exist
-          current.mode = run_specinfra(:get_file_mode, path).stdout.chomp
-          current.owner = run_specinfra(:get_file_owner_user, path).stdout.chomp
-          current.group = run_specinfra(:get_file_owner_group, path).stdout.chomp
+          current.mode = run_specinfra(:get_file_mode, attributes.path).stdout.chomp
+          current.owner = run_specinfra(:get_file_owner_user, attributes.path).stdout.chomp
+          current.group = run_specinfra(:get_file_owner_group, attributes.path).stdout.chomp
         else
           current.mode = nil
           current.owner = nil
@@ -32,14 +32,14 @@ module Itamae
       end
 
       def action_create(options)
-        if !run_specinfra(:check_file_is_directory, path)
-          run_specinfra(:create_file_as_directory, path)
+        if !run_specinfra(:check_file_is_directory, attributes.path)
+          run_specinfra(:create_file_as_directory, attributes.path)
         end
         if attributes.mode
-          run_specinfra(:change_file_mode, path, attributes.mode)
+          run_specinfra(:change_file_mode, attributes.path, attributes.mode)
         end
         if attributes.owner || attributes.group
-          run_specinfra(:change_file_owner, path, attributes.owner, attributes.group)
+          run_specinfra(:change_file_owner, attributes.path, attributes.owner, attributes.group)
         end
       end
     end

--- a/lib/itamae/resource/execute.rb
+++ b/lib/itamae/resource/execute.rb
@@ -7,7 +7,7 @@ module Itamae
       define_attribute :command, type: String, default_name: true
 
       def action_run(options)
-        run_command(command)
+        run_command(attributes.command)
         updated!
       end
     end

--- a/lib/itamae/resource/git.rb
+++ b/lib/itamae/resource/git.rb
@@ -18,8 +18,7 @@ module Itamae
       end
 
       def set_current_attributes
-        exist = run_specinfra(:check_file_is_directory, destination)
-        current.exist = exist
+        current.exist = run_specinfra(:check_file_is_directory, attributes.destination)
       end
 
       def action_sync(options)
@@ -27,15 +26,15 @@ module Itamae
 
         new_repository = false
 
-        if run_specinfra(:check_file_is_directory, destination)
+        if run_specinfra(:check_file_is_directory, attributes.destination)
           run_command_in_repo(['git', 'fetch', 'origin'])
         else
-          run_command(['git', 'clone', repository, destination])
+          run_command(['git', 'clone', attributes.repository, attributes.destination])
           new_repository = true
         end
 
-        target = if revision
-                   get_revision(revision)
+        target = if attributes.revision
+                   get_revision(attributes.revision)
                  else
                    run_command_in_repo("git ls-remote origin HEAD | cut -f1").stdout.strip
                  end
@@ -65,7 +64,7 @@ module Itamae
       end
 
       def run_command_in_repo(*args)
-        run_command(*args, cwd: destination)
+        run_command(*args, cwd: attributes.destination)
       end
 
       def current_branch

--- a/lib/itamae/resource/link.rb
+++ b/lib/itamae/resource/link.rb
@@ -15,16 +15,16 @@ module Itamae
       end
 
       def set_current_attributes
-        current.exist = run_specinfra(:check_file_is_link, link)
+        current.exist = run_specinfra(:check_file_is_link, attributes.link)
 
         if current.exist
-          current.to = run_specinfra(:get_file_link_target, link).stdout.strip
+          current.to = run_specinfra(:get_file_link_target, attributes.link).stdout.strip
         end
       end
 
       def action_create(options)
-        unless run_specinfra(:check_file_is_linked_to, link, to)
-          run_specinfra(:link_file_to, link, to)
+        unless run_specinfra(:check_file_is_linked_to, attributes.link, attributes.to)
+          run_specinfra(:link_file_to, attributes.link, attributes.to)
         end
       end
     end

--- a/lib/itamae/resource/local_ruby_block.rb
+++ b/lib/itamae/resource/local_ruby_block.rb
@@ -7,7 +7,7 @@ module Itamae
       define_attribute :block, type: Proc
 
       def action_run(options)
-        block.call
+        attributes.block.call
       end
     end
   end

--- a/lib/itamae/resource/package.rb
+++ b/lib/itamae/resource/package.rb
@@ -16,16 +16,16 @@ module Itamae
       end
 
       def set_current_attributes
-        current.installed = run_specinfra(:check_package_is_installed, name)
+        current.installed = run_specinfra(:check_package_is_installed, attributes.name)
 
         if current.installed
-          current.version = run_specinfra(:get_package_version, name).stdout.strip
+          current.version = run_specinfra(:get_package_version, attributes.name).stdout.strip
         end
       end
 
       def action_install(action_options)
-        unless run_specinfra(:check_package_is_installed, name, version)
-          run_specinfra(:install_package, name, version, options)
+        unless run_specinfra(:check_package_is_installed, attributes.name, attributes.version)
+          run_specinfra(:install_package, attributes.name, attributes.version, attributes.options)
           updated!
         end
       end

--- a/lib/itamae/resource/remote_file.rb
+++ b/lib/itamae/resource/remote_file.rb
@@ -6,7 +6,8 @@ module Itamae
       define_attribute :source, type: String, required: true
 
       def pre_action
-        content_file(::File.expand_path(source, ::File.dirname(@recipe.path)))
+        attributes.content_file =
+          ::File.expand_path(attributes.source, ::File.dirname(@recipe.path))
 
         super
       end

--- a/lib/itamae/resource/service.rb
+++ b/lib/itamae/resource/service.rb
@@ -20,32 +20,32 @@ module Itamae
       end
 
       def set_current_attributes
-        current.running = run_specinfra(:check_service_is_running, name)
-        current.enabled = run_specinfra(:check_service_is_enabled, name)
+        current.running = run_specinfra(:check_service_is_running, attributes.name)
+        current.enabled = run_specinfra(:check_service_is_enabled, attributes.name)
       end
 
       def action_start(options)
-        run_specinfra(:start_service, name)
+        run_specinfra(:start_service, attributes.name)
       end
 
       def action_stop(options)
-        run_specinfra(:stop_service, name)
+        run_specinfra(:stop_service, attributes.name)
       end
 
       def action_restart(options)
-        run_specinfra(:restart_service, name)
+        run_specinfra(:restart_service, attributes.name)
       end
 
       def action_reload(options)
-        run_specinfra(:reload_service, name)
+        run_specinfra(:reload_service, attributes.name)
       end
 
       def action_enable(options)
-        run_specinfra(:enable_service, name)
+        run_specinfra(:enable_service, attributes.name)
       end
 
       def action_disable(options)
-        run_specinfra(:disable_service, name)
+        run_specinfra(:disable_service, attributes.name)
       end
     end
   end

--- a/lib/itamae/resource/template.rb
+++ b/lib/itamae/resource/template.rb
@@ -8,8 +8,8 @@ module Itamae
       define_attribute :source, type: String, required: true
 
       def pre_action
-        src = ::File.expand_path(source, ::File.dirname(@recipe.path))
-        content(ERB.new(::File.read(src), nil, '-').result(binding))
+        src = ::File.expand_path(attributes.source, ::File.dirname(@recipe.path))
+        attributes.content = ERB.new(::File.read(src), nil, '-').result(binding)
 
         super
       end

--- a/lib/itamae/resource/user.rb
+++ b/lib/itamae/resource/user.rb
@@ -15,39 +15,39 @@ module Itamae
         current.exist = exist?
 
         if current.exist
-          current.uid = run_specinfra(:get_user_uid, username).stdout.strip
-          current.gid = run_specinfra(:get_user_gid, username).stdout.strip
-          current.home = run_specinfra(:get_user_home_directory, username).stdout.strip
+          current.uid = run_specinfra(:get_user_uid, attributes.username).stdout.strip
+          current.gid = run_specinfra(:get_user_gid, attributes.username).stdout.strip
+          current.home = run_specinfra(:get_user_home_directory, attributes.username).stdout.strip
           current.password = current_password
         end
       end
 
       def action_create(options)
-        if run_specinfra(:check_user_exists, username)
-          if uid && uid.to_s != current.uid
-            run_specinfra(:update_user_uid, username, uid)
+        if run_specinfra(:check_user_exists, attributes.username)
+          if attributes.uid && attributes.uid.to_s != current.uid
+            run_specinfra(:update_user_uid, attributes.username, attributes.uid)
             updated!
           end
 
-          if gid && gid.to_s != current.gid
-            run_specinfra(:update_user_gid, username, gid)
+          if attributes.gid && attributes.gid.to_s != current.gid
+            run_specinfra(:update_user_gid, attributes.username, attributes.gid)
             updated!
           end
 
-          if password && password != current_password
-            run_specinfra(:update_user_encrypted_password, username, password)
+          if attributes.password && attributes.password != current_password
+            run_specinfra(:update_user_encrypted_password, attributes.username, attributes.password)
             updated!
           end
         else
           options = {
-            gid:            gid,
-            home_directory: home,
-            password:       password,
-            system_user:    system_user,
-            uid:            uid,
+            gid:            attributes.gid,
+            home_directory: attributes.home,
+            password:       attributes.password,
+            system_user:    attributes.system_user,
+            uid:            attributes.uid,
           }
 
-          run_specinfra(:add_user, username, options)
+          run_specinfra(:add_user, attributes.username, options)
 
           updated!
         end
@@ -55,11 +55,11 @@ module Itamae
 
       private
       def exist?
-        run_specinfra(:check_user_exists, username)
+        run_specinfra(:check_user_exists, attributes.username)
       end
 
       def current_password
-        result = run_specinfra(:get_user_encrypted_password, username)
+        result = run_specinfra(:get_user_encrypted_password, attributes.username)
         if result.success?
           result.stdout.strip
         else

--- a/spec/unit/lib/itamae/resource/base_spec.rb
+++ b/spec/unit/lib/itamae/resource/base_spec.rb
@@ -109,7 +109,7 @@ describe TestResource do
 
   describe "#run" do
     before do
-      subject.action :name
+      subject.attributes.action = :name
     end
     it "executes <ACTION_NAME>_action method" do
       expect(subject).to receive(:action_name)


### PR DESCRIPTION
This contains incompatible changes and plugins may not work.

The biggest change is that method_missing is removed from Resource::Base class.

``` ruby
# resource definition
execute "Hello" do
  command "echo Hello"
end

# before
command # == "echo Hello"

# after
attributes.command # == "echo Hello"
```
