### PR TITLE
Do not create .bak file

### DIFF
--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -74,8 +74,6 @@ module Itamae
         end
 
         if run_specinfra(:check_file_is_file, attributes.path)
-          run_specinfra(:copy_file, attributes.path, "#{attributes.path}.bak")
-
           unless check_command(["diff", "-q", @temppath, attributes.path])
             # the file is modified
             updated!


### PR DESCRIPTION
I don't know why .bak file is created, but leaving extra files in the same directory doesn't seem sane for me...
