### PR TITLE
Let Specinfra::Configuration.sudo_password return @sudo_password

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -14,6 +14,7 @@ module Specinfra
       print "sudo password: "
       @sudo_password = STDIN.noecho(&:gets).strip
       print "\n"
+      @sudo_password
     end
   end
 end


### PR DESCRIPTION
## Problem

When I executed `itamae ssh`, I received this message.

```
 INFO : Starting Itamae...
DEBUG : Executing `mkdir -p /tmp/itamae_tmp`...
sudo password:
Wrong sudo password! Please confirm your password.
```

The sudo password I input was not wrong, but my execution failed.
## Solution

Even though [specinfra expects it to return password](https://github.com/serverspec/specinfra/blob/master/lib/specinfra/backend/ssh.rb#L113), Itamae's `Specinfra::Configuration.sudo_password` returns `nil` when you input password.
This is caused by 332661c0b40b5d2bc6a008537b59d063b0bfb37c. (`print` returns `nil`)

So I changed it to return `@sudo_password` again.
