### PR TITLE
Add password prompt to ssh

### DIFF
--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -34,6 +34,7 @@ module Itamae
     option :port, type: :numeric, aliases: ['-p']
     option :ohai, type: :boolean, default: false
     option :vagrant, type: :boolean, default: false
+    option :ask_password, type: :boolean, default: false
     def ssh(*recipe_files)
       if recipe_files.empty?
         raise "Please specify recipe files."

--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -62,7 +62,7 @@ module Itamae
             opts[:host] = opts.delete(:host_name)
           end
 
-          unless options[:key]
+          if options[:ask_password]
             print "password: "
             password = STDIN.noecho(&:gets).strip
             print "\n"


### PR DESCRIPTION
With this fix, you can access a server with password without private key.
It's useful on private network.

If you don't need this kind of feature, please close this.
