### PR TITLE
Accept --config option to specify other options

### DIFF
--- a/lib/itamae.rb
+++ b/lib/itamae.rb
@@ -9,6 +9,7 @@ require "itamae/node"
 require "itamae/backend"
 require "itamae/notification"
 require "itamae/definition"
+require "itamae/config"
 
 module Itamae
   # Your code goes here...

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -6,8 +6,9 @@ module Itamae
     class_option :log_level, type: :string, aliases: ['-l'], default: 'info'
     class_option :color, type: :boolean, default: true
 
-    def initialize(*args)
-      super
+    def initialize(args, opts, config)
+      opts = Config.new(opts).load
+      super(args, opts, config)
 
       Itamae::Logger.level = ::Logger.const_get(options[:log_level].upcase)
       Itamae::Logger.formatter.colored = options[:color]

--- a/lib/itamae/config.rb
+++ b/lib/itamae/config.rb
@@ -1,0 +1,46 @@
+require 'yaml'
+
+module Itamae
+  class Config
+    CONFIG_MATCHER = /(-c|--config) +([^ ]+)/
+
+    def initialize(options)
+      @options = options
+    end
+
+    def load
+      return @options unless config_given?
+
+      configs, options = parse_options
+      configs.each do |config|
+        options += load_config(config)
+      end
+      options
+    end
+
+    private
+
+    def parse_options
+      configs = []
+      parsed_option = joined_options.gsub(CONFIG_MATCHER).each do |match|
+        configs << Regexp.last_match[2]
+        next ''
+      end
+      [configs, parsed_option.split(' ')]
+    end
+
+    def load_config(config)
+      YAML.load(open(config)).inject([]) do |options, (key, value)|
+        options + ["--#{key}", value.to_s]
+      end
+    end
+
+    def config_given?
+      joined_options =~ CONFIG_MATCHER
+    end
+
+    def joined_options
+      @option ||= @options.join(' ')
+    end
+  end
+end

--- a/spec/unit/lib/itamae/config_spec.rb
+++ b/spec/unit/lib/itamae/config_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+module Itamae
+  describe Config do
+    describe '#load' do
+      subject { config.load }
+
+      let!(:config) { described_class.new(options) }
+
+      context 'without config option' do
+        let(:options) { ['-h', 'example.com'] }
+
+        it { is_expected.to eq(options) }
+      end
+
+      context 'with config option' do
+        let(:yaml) { 'port: 22' }
+
+        before { allow(config).to receive(:open).and_return(yaml) }
+
+        context 'when short option' do
+          let(:options) { ['-h', 'example.com', '-c', 'config.yml'] }
+
+          it { is_expected.to eq(['-h', 'example.com', '--port', '22']) }
+        end
+
+        context 'when long option' do
+          let(:options) { ['-h', 'example.com', '--config', 'config.yml'] }
+
+          it { is_expected.to eq(['-h', 'example.com', '--port', '22']) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It is boring to write options many times. Thus I propose another way to specify options.
~~With this change, you can specify options with `.itamae` in current directory, which is written in yaml.~~

You can specify options by configuration YAML, which is choosed by `--config`(`-c`) option.
## Example

If you create following `config.yml`,

``` yaml
host: 192.168.10.10
port: 22
user: user
key: /path/to/private_key
```

you can execute `itamae` without many options.

``` bash
# same as: itamae recipe.rb -h 192.168.10.10 -p 22 -u user -i /path/to/private_key
$ itamae recipe.rb -c config.yml
```
