### PR TITLE
Support yaml as node

### DIFF
--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -15,6 +15,7 @@ module Itamae
 
     desc "local RECIPE [RECIPE...]", "Run Itamae locally"
     option :node_json, type: :string, aliases: ['-j']
+    option :node_yaml, type: :string, aliases: ['-y']
     option :dry_run, type: :boolean, aliases: ['-n']
     option :ohai, type: :boolean, default: false
     def local(*recipe_files)
@@ -27,6 +28,7 @@ module Itamae
 
     desc "ssh RECIPE [RECIPE...]", "Run Itamae via ssh"
     option :node_json, type: :string, aliases: ['-j']
+    option :node_yaml, type: :string, aliases: ['-y']
     option :dry_run, type: :boolean, aliases: ['-n']
     option :host, required: true, type: :string, aliases: ['-h']
     option :user, type: :string, aliases: ['-u']

--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -1,5 +1,6 @@
 require 'itamae'
 require 'json'
+require 'yaml'
 
 module Itamae
   class Runner
@@ -33,6 +34,12 @@ module Itamae
           path = File.expand_path(options[:node_json])
           Logger.info "Loading node data from #{path}..."
           hash.merge!(JSON.load(open(path)))
+        end
+
+        if options[:node_yaml]
+          path = File.expand_path(options[:node_yaml])
+          Logger.info "Loading node data from #{path}..."
+          hash.merge!(YAML.load(open(path)))
         end
 
         Node.new(hash)


### PR DESCRIPTION
Node object is useful but json format is not so useful to write.
I'm happy if itamae supports yaml format for node object.
## Example

``` bash
$ cat node.yml
user: hoge
$ itamae execute -y node.yml recipe.rb
```

is the same as:

``` bash
$ cat node.json
{
  "user": "hoge"
}
$ itamae execute -j node.json recipe.rb
```
