### PR TITLE
package resouse using `user attribute`

### DIFF
--- a/lib/itamae/resource/package.rb
+++ b/lib/itamae/resource/package.rb
@@ -25,7 +25,8 @@ module Itamae
 
       def action_install(action_options)
         unless run_specinfra(:check_package_is_installed, attributes.name, attributes.version)
-          run_specinfra(:install_package, attributes.name, attributes.version, attributes.options)
+          command = Specinfra.command.get(:install_package, attributes.name, attributes.version, attributes.options)
+          run_command(command, {user: attributes.user})
           updated!
         end
       end


### PR DESCRIPTION
This problem occur at ssh connected to OSX(darwin).
In this case package installed by "root" user. but OSX packaging system brew's user is "not root" user.

This patch is using `user attribute` to package resource.

rebase by #60 .
