### PR TITLE
uid and gid should be an integer

### DIFF
--- a/lib/itamae/resource/user.rb
+++ b/lib/itamae/resource/user.rb
@@ -9,13 +9,13 @@ module Itamae
       define_attribute :home, type: String
       define_attribute :password, type: String
       define_attribute :system_user, type: [TrueClass, FalseClass]
-      define_attribute :uid, type: [String, Integer]
+      define_attribute :uid, type: Integer
 
       def set_current_attributes
         current.exist = exist?
 
         if current.exist
-          current.uid = run_specinfra(:get_user_uid, attributes.username).stdout.strip
+          current.uid = run_specinfra(:get_user_uid, attributes.username).stdout.strip.to_i
           current.gid = run_specinfra(:get_user_gid, attributes.username).stdout.strip.to_i
           current.home = run_specinfra(:get_user_home_directory, attributes.username).stdout.strip
           current.password = current_password
@@ -24,7 +24,7 @@ module Itamae
 
       def action_create(options)
         if run_specinfra(:check_user_exists, attributes.username)
-          if attributes.uid && attributes.uid.to_s != current.uid
+          if attributes.uid && attributes.uid != current.uid
             run_specinfra(:update_user_uid, attributes.username, attributes.uid)
             updated!
           end


### PR DESCRIPTION
When I specify an integer uid, itamae always notifies uid changes.

```
...
 INFO :       user[eagletmt]
 INFO :          action: create
 INFO :             uid will change from '1000' to '1000'
...
```

My suggestion is force uid and gid to be an integer.
