### PR TITLE
Make `node` handle NameError from host_inventory

### DIFF
--- a/lib/itamae/node.rb
+++ b/lib/itamae/node.rb
@@ -17,7 +17,7 @@ module Itamae
       if val.nil?
         begin
           val = host_inventory[key]
-        rescue NotImplementedError
+        rescue NotImplementedError, NameError
           val = nil
         end
       end

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -34,6 +34,7 @@ describe file('/tmp/template') do
   its(:content) { should match(/Hello/) }
   its(:content) { should match(/Good bye/) }
   its(:content) { should match(/^total memory: \d+kB$/) }
+  its(:content) { should match(/^uninitialized node key: $/) }
 end
 
 describe file('/tmp/file') do

--- a/spec/integration/recipes/hello.erb
+++ b/spec/integration/recipes/hello.erb
@@ -2,3 +2,5 @@
 <%= @goodbye %>
 
 total memory: <%= node['memory']['total'] %>
+
+uninitialized node key: <%= node['un-initialized'] %>


### PR DESCRIPTION
I found two errors of `node`.

First one is as follows.
It is found with `node["undefined"]`:

```
/Users/nownabe/itamae-test/vendor/bundle/ruby/2.2.0/gems/specinfra-2.12.1/lib/specinfra/host_inventory.rb:22:in `const_get': uninitialized constant Undefined (NameError)
	from /Users/nownabe/itamae-test/vendor/bundle/ruby/2.2.0/gems/specinfra-2.12.1/lib/specinfra/host_inventory.rb:22:in `[]'
	from /Users/nownabe/itamae-test/vendor/bundle/ruby/2.2.0/gems/itamae-1.1.3/lib/itamae/node.rb:19:in `[]'
	from /Users/nownabe/itamae-test/recipe.rb:1:in `initialize'
```

Second one is as follows.
It is found with `node["un-defined"]`:

```
/Users/nownabe/itamae-test/vendor/bundle/ruby/2.2.0/gems/specinfra-2.12.1/lib/specinfra/host_inventory.rb:22:in `const_get': wrong constant name Un-defined (NameError)
	from /Users/nownabe/itamae-test/vendor/bundle/ruby/2.2.0/gems/specinfra-2.12.1/lib/specinfra/host_inventory.rb:22:in `[]'
	from /Users/nownabe/itamae-test/vendor/bundle/ruby/2.2.0/gems/itamae-1.1.3/lib/itamae/node.rb:19:in `[]'
	from /Users/nownabe/itamae-test/recipe.rb:1:in `initialize'
```