### PR TITLE
Display updated message always

### DIFF
--- a/lib/itamae/resource/base.rb
+++ b/lib/itamae/resource/base.rb
@@ -310,9 +310,7 @@ module Itamae
       end
 
       def updated!
-        unless @updated
-          Logger.debug "This resource is updated."
-        end
+        Logger.debug "This resource is updated."
         @updated = true
       end
 


### PR DESCRIPTION
ひとつのリソース内で action が2つ以上ある場合に、複数の action で変更があっても、最初に変更があった action でしか 「This resource is updated.」という DEBUG ログが表示されません。例えば以下のように、httpd service で action [:enable, :start] を指定すると、最初の enable action では「This resource is updated.」 が表示されますが、start action では表示されません。

```
 INFO : Starting Itamae...
DEBUG : Executing `mkdir -p /tmp/itamae_tmp`...
DEBUG :    exited with 0
DEBUG : Executing `chmod 777 /tmp/itamae_tmp`...
DEBUG :    exited with 0
 INFO : Recipe: /Users/mizzy/tmp/serverspec/recipe.rb
 INFO :    service[httpd]
 INFO :       action: enable
DEBUG :          (in pre_action)
DEBUG :          (in set_current_attributes)
DEBUG :          Executing `service httpd status`...
DEBUG :             exited with 3
DEBUG :             stdout | httpd is stopped
DEBUG :          Executing `chkconfig --list httpd | grep 3:on`...
DEBUG :             exited with 1
DEBUG :          (in show_differences)
DEBUG :          running will not change (current value is 'false')
 INFO :          enabled will change from 'false' to 'true'
DEBUG :          This resource is updated.
 INFO :       action: start
DEBUG :          (in pre_action)
DEBUG :          (in set_current_attributes)
DEBUG :          Executing `service httpd status`...
DEBUG :             exited with 3
DEBUG :             stdout | httpd is stopped
DEBUG :          Executing `chkconfig --list httpd | grep 3:on`...
DEBUG :             exited with 1
DEBUG :          (in show_differences)
 INFO :          running will change from 'false' to 'true'
 INFO :          enabled will change from 'false' to 'true'
```

~~そこで、run_action を実行するたびに、@updated を false に設定するようにしてみました。~~ 助言に従い、`updated!` が呼ばれたら必ず表示するようにしました。

確認お願いします。
