### PR TITLE
Set log color explicitly

### DIFF
--- a/lib/itamae/logger.rb
+++ b/lib/itamae/logger.rb
@@ -7,6 +7,7 @@ module Itamae
     class Formatter
       attr_accessor :colored
       attr_accessor :depth
+      attr_accessor :color
 
       INDENT_LENGTH = 3
 
@@ -19,7 +20,7 @@ module Itamae
       def call(severity, datetime, progname, msg)
         log = "%s : %s%s\n" % ["%5s" % severity, ' ' * INDENT_LENGTH * depth , msg2str(msg)]
         if colored
-          color(log, severity)
+          colorize(log, severity)
         else
           log
         end
@@ -30,6 +31,14 @@ module Itamae
         yield
       ensure
         @depth -= 1
+      end
+
+      def color(code)
+        @prev_color = @color
+        @color = code
+        yield
+      ensure
+        @color = @prev_color
       end
 
       private
@@ -45,17 +54,21 @@ module Itamae
         end
       end
 
-      def color(str, severity)
-        color_code = case severity
-                     when "INFO"
-                       :green
-                     when "WARN"
-                       :magenta
-                     when "ERROR"
-                       :red
-                     else
-                       :clear
-                     end
+      def colorize(str, severity)
+        if @color
+          color_code = @color
+        else
+          color_code = case severity
+                       when "INFO"
+                         :clear
+                       when "WARN"
+                         :magenta
+                       when "ERROR"
+                         :red
+                       else
+                         :clear
+                       end
+        end
         ANSI.public_send(color_code) { str }
       end
     end
@@ -73,7 +86,7 @@ module Itamae
         @log_device = value
         @logger = create_logger
       end
-      
+
       private
 
       def create_logger

--- a/lib/itamae/resource/base.rb
+++ b/lib/itamae/resource/base.rb
@@ -205,11 +205,15 @@ module Itamae
           if current_value.nil? && value.nil?
             # ignore
           elsif current_value.nil? && !value.nil?
-            Logger.info "#{key} will be '#{value}'"
+            Logger.formatter.color :green do
+              Logger.info "#{key} will be '#{value}'"
+            end
           elsif current_value == value || value.nil?
             Logger.debug "#{key} will not change (current value is '#{current_value}')"
           else
-            Logger.info "#{key} will change from '#{current_value}' to '#{value}'"
+            Logger.formatter.color :green do
+              Logger.info "#{key} will change from '#{current_value}' to '#{value}'"
+            end
           end
         end
       end


### PR DESCRIPTION
変更があった場合だけわかりやすくログを緑で表示するために、同じ severity でも色を変えられるようにしてみました。 `indent` と同じように、以下のように書くことで色を指定します。

```ruby
Logger.formatter.color :green do
  Logger.info "#{key} will be '#{value}'"
end
```
このような出力になります。

![itamae_log](https://cloud.githubusercontent.com/assets/3620/6199003/e304109a-b469-11e4-97cf-d4ec132e4041.png)

問題がないか、確認お願いします！＞ @ryotarai 
