### PR TITLE
remove reqirement of --host option for ssh command

### DIFF
--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -33,7 +33,7 @@ module Itamae
     option :node_json, type: :string, aliases: ['-j']
     option :node_yaml, type: :string, aliases: ['-y']
     option :dry_run, type: :boolean, aliases: ['-n']
-    option :host, required: true, type: :string, aliases: ['-h']
+    option :host, type: :string, aliases: ['-h']
     option :user, type: :string, aliases: ['-u']
     option :key, type: :string, aliases: ['-i']
     option :port, type: :numeric, aliases: ['-p']
@@ -44,6 +44,10 @@ module Itamae
     def ssh(*recipe_files)
       if recipe_files.empty?
         raise "Please specify recipe files."
+      end
+
+      unless options[:host] || options[:vagrant]
+        raise "Please set '-h <hostname>' or '--vagrant'"
       end
 
       Runner.run(recipe_files, :ssh, options)

--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -69,8 +69,9 @@ module Itamae
 
           if options[:vagrant]
             config = Tempfile.new('', Dir.tmpdir)
-            `vagrant ssh-config > #{config.path}`
-            opts.merge!(Net::SSH::Config.for('default', [config.path]))
+            hostname = opts[:host] || 'default'
+            `vagrant ssh-config #{hostname} > #{config.path}`
+            opts.merge!(Net::SSH::Config.for(hostname, [config.path]))
             opts[:host] = opts.delete(:host_name)
           end
 

--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -69,8 +69,8 @@ module Itamae
 
           if options[:vagrant]
             config = Tempfile.new('', Dir.tmpdir)
-            `vagrant ssh-config #{opts[:host]} > #{config.path}`
-            opts.merge!(Net::SSH::Config.for(opts[:host], [config.path]))
+            `vagrant ssh-config > #{config.path}`
+            opts.merge!(Net::SSH::Config.for('default', [config.path]))
             opts[:host] = opts.delete(:host_name)
           end
 


### PR DESCRIPTION
This pull request includes a proposal and a bugfix.

### Proposal

I don't think we need `--host` option when `--vagrant` is provided. Just `itamae ssh --vagrant recipi.rb` is enough. So I remove `required: true` from ssh command and add validation instead.

### Bugfix

`vagrant ssh-config #{opts[:host]}` is invalid command on latest version of vagrant (1.7.2). Available commands are `vagrant ssh-config` and `vagrant ssh-config --host <hostname>`.

    $ vagrant ssh-config
    Host default
      HostName xxxx
      User xxxx
      Port xxxx
      UserKnownHostsFile /dev/null
      StrictHostKeyChecking no
      PasswordAuthentication no
      IdentityFile /path/to/keyfile
      IdentitiesOnly yes
      LogLevel FATAL

    $ vagrant ssh-config --host somehost
    Host somehost
      HostName xxxx
      User xxxx
      Port xxxx
      UserKnownHostsFile /dev/null
      StrictHostKeyChecking no
      PasswordAuthentication no
      IdentityFile /path/to/keyfile
      IdentitiesOnly yes
      LogLevel FATAL

In this pull request, I want to ignore `--host` option, so just use `vagrant ssh-config` and settings for `default` host.

I hope I can get any feedback!