### PR TITLE
Ignore CommandExecutionError in dry-run mode

### DIFF
--- a/lib/itamae/resource/gem_package.rb
+++ b/lib/itamae/resource/gem_package.rb
@@ -59,6 +59,8 @@ module Itamae
           end
         end
         gems
+      rescue Backend::CommandExecutionError
+        []
       end
 
       def install!


### PR DESCRIPTION
When Ruby will be installed by another recipe but the recipe isn't
applied yet, `gem_package` resource with dry-run mode raises an error
because `gem list -l` command fails. CommandExecutionError should be
ignored during getting installed gems.