### PR TITLE
Make finalize method public

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -176,6 +176,11 @@ module Itamae
     end
 
     class Docker < Base
+      def finalize
+        image = @backend.commit_container
+        Logger.info "Image created: #{image.id}"
+      end
+
       private
       def create_specinfra_backend
         begin
@@ -192,11 +197,6 @@ module Itamae
           docker_image: @options[:image],
           docker_container: @options[:container],
         )
-      end
-
-      def finalize
-        image = @backend.commit_container
-        Logger.info "Image created: #{image.id}"
       end
     end
   end


### PR DESCRIPTION
Because itamae/runner.rb calls `@backend.finalize`.

Without this fix, error occurs like below:

```
/Users/mizzy/src/github.com/itamae-kitchen/itamae/lib/itamae/runner.rb:54:in `run': private method `finalize' called for #<Itamae::Backend::Docker:0x007fba13cfef20> (NoMethodError)
        from /Users/mizzy/src/github.com/itamae-kitchen/itamae/lib/itamae/runner.rb:23:in `run'
        from /Users/mizzy/src/github.com/itamae-kitchen/itamae/lib/itamae/cli.rb:69:in `docker'
        from /Users/mizzy/src/github.com/serverspec/serverspec-integration-test/vendor/bundle/ruby/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from /Users/mizzy/src/github.com/serverspec/serverspec-integration-test/vendor/bundle/ruby/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /Users/mizzy/src/github.com/serverspec/serverspec-integration-test/vendor/bundle/ruby/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from /Users/mizzy/src/github.com/serverspec/serverspec-integration-test/vendor/bundle/ruby/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /Users/mizzy/src/github.com/itamae-kitchen/itamae/bin/itamae:4:in `<top (required)>'
        from /Users/mizzy/src/github.com/serverspec/serverspec-integration-test/vendor/bundle/ruby/2.1.0/bin/itamae:23:in `load'
        from /Users/mizzy/src/github.com/serverspec/serverspec-integration-test/vendor/bundle/ruby/2.1.0/bin/itamae:23:in `<main>'
```

Please check it.
