### PR TITLE
Show difference of user resource when was created

### DIFF
--- a/lib/itamae/resource/user.rb
+++ b/lib/itamae/resource/user.rb
@@ -11,6 +11,13 @@ module Itamae
       define_attribute :system_user, type: [TrueClass, FalseClass]
       define_attribute :uid, type: Integer
 
+      def pre_action
+        case @current_action
+        when :create
+          attributes.exist = true
+        end
+      end
+
       def set_current_attributes
         current.exist = exist?
 
@@ -74,4 +81,3 @@ module Itamae
     end
   end
 end
-


### PR DESCRIPTION
Now, don't show difference of user resource when user was created.

Example:

```ruby
# roles/user.rb

user 'gongo'
```

```
$ vagrant ssh default -- ls /home
vagrant

$ bundle exec itamae ssh -h default --vagrant roles/user.rb
 INFO : Starting Itamae...
 INFO : Recipe: /path/to/server/roles/user.rb 
         # <= Nothing !

$ vagrant ssh default -- ls /home
gongo
vagrant
```

After merged this branch:

```
 INFO : Starting Itamae...
 INFO : Recipe: /path/to/server/roles/user.rb
 INFO :   user[gongo] exist will change from 'false' to 'true'
```