### PR TITLE
Fix a glitch on raising exception when source doesn't exist.

### DIFF
--- a/itamae.gemspec
+++ b/itamae.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "serverspec", "~> 2.1"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "docker-api", "~> 1.20"
+  spec.add_development_dependency "fakefs"
 end

--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -26,6 +26,7 @@ module Itamae
   module Backend
     UnknownBackendTypeError = Class.new(StandardError)
     CommandExecutionError = Class.new(StandardError)
+    SourceNotExistError = Class.new(StandardError)
 
     class << self
       def create(type, opts = {})
@@ -119,18 +120,21 @@ module Itamae
       def send_file(src, dst)
         Logger.debug "Sending a file from '#{src}' to '#{dst}'..."
         unless ::File.exist?(src)
-          raise Error, "The file '#{src}' doesn't exist."
+          raise SourceNotExistError, "The file '#{src}' doesn't exist."
+        end
+        unless ::File.file?(src)
+          raise SourceNotExistError, "'#{src}' is not a file."
         end
         @backend.send_file(src, dst)
       end
 
       def send_directory(src, dst)
         Logger.debug "Sending a directory from '#{src}' to '#{dst}'..."
-        unless ::File.directory?(src)
-          raise Error, "'#{src}' is not directory."
-        end
         unless ::File.exist?(src)
-          raise Error, "The directory '#{src}' doesn't exist."
+          raise SourceNotExistError, "The directory '#{src}' doesn't exist."
+        end
+        unless ::File.directory?(src)
+          raise SourceNotExistError, "'#{src}' is not a directory."
         end
         @backend.send_directory(src, dst)
       end

--- a/spec/unit/lib/itamae/backend_spec.rb
+++ b/spec/unit/lib/itamae/backend_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'fakefs/spec_helpers'
+
+module Itamae
+  module Backend
+    describe Base do
+      include FakeFS::SpecHelpers
+
+      class Klass < Itamae::Backend::Base
+        def initialize(_)
+          @backend = Object.new
+          @backend.stub(:send_file)
+          @backend.stub(:send_directory)
+        end
+      end
+
+      describe ".send_file" do
+        context "the source file doesn't exist" do
+          subject { -> { Klass.new("dummy").send_file("src", "dst") } }
+          it { expect(subject).to raise_error(Itamae::Backend::SourceNotExistError, "The file 'src' doesn't exist.") }
+        end
+
+        context "the source file exist, but it is not a regular file" do
+          before { Dir.mkdir("src")  }
+          subject { -> { Klass.new("dummy").send_file("src", "dst") } }
+          it { expect(subject).to raise_error(Itamae::Backend::SourceNotExistError, "'src' is not a file.") }
+        end
+
+        context "the source file is a regular file" do
+          before { FileUtils.touch("src")  }
+          subject { -> { Klass.new("dummy").send_file("src", "dst") } }
+          it { expect { subject }.not_to raise_error }
+        end
+      end
+
+      describe ".send_directory" do
+        context "the source directory doesn't exist" do
+          subject { -> { Klass.new("dummy").send_directory("src", "dst") } }
+          it { expect(subject).to raise_error(Itamae::Backend::SourceNotExistError, "The directory 'src' doesn't exist.") }
+        end
+
+        context "the source directory exist, but it is not a directory" do
+          before { FileUtils.touch("src")  }
+          subject { -> { Klass.new("dummy").send_directory("src", "dst") } }
+          it { expect(subject).to raise_error(Itamae::Backend::SourceNotExistError, "'src' is not a directory.") }
+        end
+
+        context "the source directory is a directory" do
+          before { Dir.mkdir("src")  }
+          subject { -> { Klass.new("dummy").send_directory("src", "dst") } }
+          it { expect { subject }.not_to raise_error }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I found a glitch when source file or directory doesn't exist.

For example, there is a itamae recipe file,

```ruby
remote_directory "/path/to/destination" do
  source "/path/to/source"
end
```

When `/path/to/source` does not exist, itamae says following exception message,
```
backend.rb:130:in `send_directory': uninitialized constant Itamae::Backend::Base::Error (NameError)
```

So I fixed the problem by using `SourceNotExistError`.