### PR TITLE
Fix for disable_sudo option

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -168,7 +168,7 @@ module Itamae
         Specinfra::Backend::Ssh.new(
           request_pty: true,
           host: ssh_options[:host_name],
-          disable_sudo: ssh_options[:disable_sudo],
+          disable_sudo: disable_sudo?,
           ssh_options: ssh_options,
         )
       end
@@ -183,7 +183,6 @@ module Itamae
         opts[:user] = @options[:user] || opts[:user] || Etc.getlogin
         opts[:keys] = [@options[:key]] if @options[:key]
         opts[:port] = @options[:port] if @options[:port]
-        opts[:disable_sudo] = true unless @options[:sudo]
 
         if @options[:vagrant]
           config = Tempfile.new('', Dir.tmpdir)
@@ -200,6 +199,10 @@ module Itamae
         end
 
         opts
+      end
+
+      def disable_sudo?
+        !@options[:sudo]
       end
     end
 

--- a/spec/unit/lib/itamae/backend_spec.rb
+++ b/spec/unit/lib/itamae/backend_spec.rb
@@ -52,5 +52,43 @@ module Itamae
         end
       end
     end
+
+    describe Ssh do
+
+      describe "#ssh_options" do
+        subject { ssh.send(:ssh_options) }
+
+        let!(:ssh) { described_class.new(options) }
+        let!(:host_name) { "example.com" }
+        let!(:default_option) do
+          opts = {}
+          opts[:host_name] = nil
+          opts.merge!(Net::SSH::Config.for(host_name))
+          opts[:user] = opts[:user] || Etc.getlogin
+          opts
+        end
+
+        context "with host option" do
+          let(:options) { {host: host_name} }
+          it { is_expected.to eq( default_option.merge({host_name: host_name}) ) }
+        end
+      end
+
+      describe "#disable_sudo?" do
+        subject { ssh.send(:disable_sudo?) }
+
+        let!(:ssh) { described_class.new(options)}
+
+        context "when sudo option is true" do
+          let(:options) { {sudo: true} }
+          it { is_expected.to eq(false) }
+        end
+
+        context "when sudo option is false" do
+          let(:options) { {sudo: false} }
+          it { is_expected.to eq(true) }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When using ssh with `--sudo=false` option, it results in error for `net-ssh`.
`disable_sudo` is not valid option in `net-ssh`, so move it from `ssh_options`.