### PR TITLE
Add "force" attribute to link resource

### DIFF
--- a/itamae.gemspec
+++ b/itamae.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "thor"
-  spec.add_runtime_dependency "specinfra", [">= 2.29.0", "< 3.0.0"]
+  spec.add_runtime_dependency "specinfra", [">= 2.31.0", "< 3.0.0"]
   spec.add_runtime_dependency "hashie"
   spec.add_runtime_dependency "ansi"
   spec.add_runtime_dependency "schash", "~> 0.1.0"

--- a/lib/itamae/resource/link.rb
+++ b/lib/itamae/resource/link.rb
@@ -6,6 +6,7 @@ module Itamae
       define_attribute :action, default: :create
       define_attribute :link, type: String, default_name: true
       define_attribute :to, type: String, required: true
+      define_attribute :force, default: false
 
       def pre_action
         case @current_action
@@ -24,7 +25,7 @@ module Itamae
 
       def action_create(options)
         unless run_specinfra(:check_file_is_linked_to, attributes.link, attributes.to)
-          run_specinfra(:link_file_to, attributes.link, attributes.to)
+          run_specinfra(:link_file_to, attributes.link, attributes.to, force: attributes.force)
         end
       end
     end

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -97,6 +97,10 @@ describe file('/tmp-link') do
   end
 end
 
+describe file('/tmp-link-force') do
+  it { should be_linked_to '/tmp' }
+end
+
 describe command('cd /tmp/git_repo && git rev-parse HEAD') do
   its(:stdout) { should match(/3116e170b89dc0f7315b69c1c1e1fd7fab23ac0d/) }
 end

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -170,6 +170,12 @@ link "/tmp-link" do
   to "/tmp"
 end
 
+execute "touch /tmp-link-force"
+link "/tmp-link-force" do
+  to "/tmp"
+  force true
+end
+
 #####
 
 local_ruby_block "greeting" do


### PR DESCRIPTION
既にファイルかシンボリックリンクが存在する場合にlinkがこけるので、forceオプションを使えるようにしてみました。

```
$ cat itamae/cookbooks/base/default.rb
link "/etc/localtime" do
  to "/usr/share/zoneinfo/Japan"
en

$ bundle exec itamae ssh --host test01.mikeda.jp itamae/cookbooks/base/default.rb 
 INFO : Starting Itamae...
 INFO : Recipe: /Users/tomohiro-ikeda/work/sysadmin2/itamae/cookbooks/base/default.rb
 INFO :   link[/etc/localtime] exist will change from 'false' to 'true'
ERROR :     Command `ln -s /usr/share/zoneinfo/Japan /etc/localtime` failed. (exit status: 1)
ERROR :     stdout | ln: failed to create symbolic link ‘/etc/localtime’: File exists

ERROR :   link[/etc/localtime] Failed.
```