### PR TITLE
Show error message when specified action is unavailable in dry_run mode

### DIFF
--- a/lib/itamae/resource/base.rb
+++ b/lib/itamae/resource/base.rb
@@ -184,8 +184,13 @@ module Itamae
           Logger.debug "(in show_differences)"
           show_differences
 
-          unless options[:dry_run]
-            public_send("action_#{action}".to_sym, options)
+          method_name = "action_#{action}"
+          if options[:dry_run]
+            unless respond_to?(method_name)
+              Logger.error "action #{action.inspect} is unavailable"
+            end
+          else
+            public_send(method_name, options)
           end
 
           updated! if different?

--- a/spec/unit/lib/itamae/resource/base_spec.rb
+++ b/spec/unit/lib/itamae/resource/base_spec.rb
@@ -113,10 +113,21 @@ describe TestResource do
   describe "#run" do
     before do
       subject.attributes.action = :name
+      allow(Itamae::Logger).to receive(:debug)  # suppress logger output
     end
+
     it "executes <ACTION_NAME>_action method" do
       expect(subject).to receive(:action_name)
       subject.run
+    end
+
+    context 'with dry_run' do
+      context 'when specified action is unavailable' do
+        it 'logs error' do
+          expect(Itamae::Logger).to receive(:error).with(/action :name is unavailable/)
+          subject.run(nil, dry_run: true)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Because I often make a mistake in action name :trollface: 