### PR TITLE
Add "recursive" attribute to git resource

### DIFF
--- a/lib/itamae/resource/git.rb
+++ b/lib/itamae/resource/git.rb
@@ -30,11 +30,6 @@ module Itamae
         if run_specinfra(:check_file_is_directory, attributes.destination)
           run_command_in_repo(['git', 'fetch', 'origin'])
         else
-          if attributes.recursive
-            run_command(['git', 'clone', '--recursive', attributes.repository, attributes.destination])
-          else
-            run_command(['git', 'clone', attributes.repository, attributes.destination])
-          end
           cmd = ['git', 'clone']
           cmd << '--recursive' if attributes.recursive
           cmd << attributes.repository << attributes.destination

--- a/lib/itamae/resource/git.rb
+++ b/lib/itamae/resource/git.rb
@@ -9,6 +9,7 @@ module Itamae
       define_attribute :destination, type: String, default_name: true
       define_attribute :repository, type: String, required: true
       define_attribute :revision, type: String
+      define_attribute :recursive, default: false
 
       def pre_action
         case @current_action
@@ -29,7 +30,11 @@ module Itamae
         if run_specinfra(:check_file_is_directory, attributes.destination)
           run_command_in_repo(['git', 'fetch', 'origin'])
         else
-          run_command(['git', 'clone', attributes.repository, attributes.destination])
+          if attributes.recursive
+            run_command(['git', 'clone', '--recursive', attributes.repository, attributes.destination])
+          else
+            run_command(['git', 'clone', attributes.repository, attributes.destination])
+          end
           new_repository = true
         end
 

--- a/lib/itamae/resource/git.rb
+++ b/lib/itamae/resource/git.rb
@@ -35,6 +35,10 @@ module Itamae
           else
             run_command(['git', 'clone', attributes.repository, attributes.destination])
           end
+          cmd = ['git', 'clone']
+          cmd << '--recursive' if attributes.recursive
+          cmd << attributes.repository << attributes.destination
+          run_command(cmd)
           new_repository = true
         end
 

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -109,6 +109,10 @@ describe command('cd /tmp/git_repo && git rev-parse HEAD') do
   its(:stdout) { should match(/3116e170b89dc0f7315b69c1c1e1fd7fab23ac0d/) }
 end
 
+describe command('cd /tmp/git_repo_submodule/empty_repo && cat README.md') do
+  its(:stdout) { should match(/Empty Repo/) }
+end
+
 describe file('/tmp/created_by_itamae_user') do
   it { should be_file }
   it { should be_owned_by 'itamae' }

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -211,6 +211,11 @@ git "/tmp/git_repo" do
   revision "v0.1.0"
 end
 
+git "/tmp/git_repo_submodule" do
+  repository "https://github.com/mmasaki/fake_repo_including_submodule.git"
+  recursive true
+end
+
 #####
 
 execute "echo -n $HOME > /tmp/created_by_itamae_user" do


### PR DESCRIPTION
I propose an new attribute "recursive" into git resource.

Example:
```
git "foo" do
  repository "https://github.com/foo/including_submodules.git"
  recursive true
end
```

Then, "git clone --recursive https://github.com/foo/including_submodules.git" will be executed.