### PR TITLE
Add disable_sudo to each resource

### DIFF
--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -169,3 +169,15 @@ describe file('/home/itamae2') do
   it { should be_owned_by "itamae2" }
   it { should be_grouped_into "itamae2" }
 end
+
+describe file('/tmp/disable_sudo_is_false') do
+  it { should be_file }
+  its(:content) { should eq("root\n") }
+end
+
+describe file('/tmp/disable_sudo_is_true') do
+  let(:current_user) { Specinfra.configuration.ssh_options[:user] }
+
+  it { should be_file }
+  its(:content) { should eq("#{current_user}\n") }
+end

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -353,3 +353,13 @@ v3 = node['memory']['total']
 unless v1 == v2 && v2 == v3 && v1 =~ /\A\d+kB\z/
   raise "failed to fetch host inventory value (#{v1}, #{v2}, #{v3})"
 end
+
+###
+
+execute "whoami > /tmp/disable_sudo_is_false" do
+  disable_sudo false
+end
+
+execute "whoami > /tmp/disable_sudo_is_true" do
+  disable_sudo true
+end


### PR DESCRIPTION
# Feature
disable sudo only in a specified resource.

It likes to `let(:disable_sudo) { true }`  in Serverspec

# Example
```sh
itamae ssh --sudo
```

```ruby
execute "whoami" do
  disable_sudo false
end
# => sudo whoami

execute "whoami" do
  disable_sudo true
end
# => whoami
```
