### PR TITLE
docker command options are not enough

### DIFF
--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -59,7 +59,8 @@ module Itamae
     option :node_yaml, type: :string, aliases: ['-y']
     option :dry_run, type: :boolean, aliases: ['-n']
     option :ohai, type: :boolean, default: false, desc: "This option is DEPRECATED and will be inavailable."
-    option :image, type: :string, required: true
+    option :image, type: :string, desc: "This option or 'container' option is required."
+    option :container, type: :string, desc: "This option or 'image' option is required."
     option :tls_verify_peer, type: :boolean, default: true
     def docker(*recipe_files)
       if recipe_files.empty?
@@ -75,4 +76,3 @@ module Itamae
     end
   end
 end
-


### PR DESCRIPTION
Currently, Itamae is ready to provision the running container.
But, it can't provision them.
Because the command options are not enough.

https://github.com/itamae-kitchen/itamae/blob/master/lib/itamae/backend.rb#L227-L230
https://github.com/serverspec/specinfra/blob/master/lib/specinfra/backend/docker.rb#L15-L22