### PR TITLE
Change recieving options in Itamae::Resource::Base at initialize time

### DIFF
--- a/lib/itamae/recipe.rb
+++ b/lib/itamae/recipe.rb
@@ -46,20 +46,20 @@ module Itamae
       show_banner
 
       Logger.formatter.with_indent do
-        @children.run(options)
-        run_delayed_notifications(options)
+        @children.run(@options)
+        run_delayed_notifications
       end
     end
 
     private
 
-    def run_delayed_notifications(options)
+    def run_delayed_notifications
       @delayed_notifications.uniq! do |notification|
         [notification.action, notification.action_resource]
       end
 
       while notification = @delayed_notifications.shift
-        notification.run(options)
+        notification.run(@options)
       end
     end
 

--- a/lib/itamae/recipe.rb
+++ b/lib/itamae/recipe.rb
@@ -25,11 +25,12 @@ module Itamae
       end
     end
 
-    def initialize(runner, path)
+    def initialize(runner, path, options = {})
       @runner = runner
       @path = path
       @delayed_notifications = []
       @children = RecipeChildren.new
+      @options = options
     end
 
     def dir
@@ -37,7 +38,7 @@ module Itamae
     end
 
     def load(vars = {})
-      context = EvalContext.new(self, vars)
+      context = EvalContext.new(self, vars, @options)
       context.instance_eval(File.read(path), path, 1)
     end
 
@@ -67,8 +68,9 @@ module Itamae
     end
 
     class EvalContext
-      def initialize(recipe, vars)
+      def initialize(recipe, vars, options = {})
         @recipe = recipe
+        @options = options
 
         vars.each do |k, v|
           define_singleton_method(k) { v }
@@ -92,7 +94,7 @@ module Itamae
           super
         end
 
-        resource = klass.new(@recipe, name, &block)
+        resource = klass.new(@recipe, name, @options, &block)
         @recipe.children << resource
       end
 
@@ -116,7 +118,7 @@ module Itamae
           return
         end
 
-        recipe = Recipe.new(runner, path)
+        recipe = Recipe.new(runner, path, @options)
         @recipe.children << recipe
         recipe.load
       end
@@ -138,7 +140,7 @@ module Itamae
       attr_accessor :definition
 
       def load(vars = {})
-        context = EvalContext.new(self, vars)
+        context = EvalContext.new(self, vars, @options)
         context.instance_eval(&@definition.class.definition_block)
       end
 

--- a/lib/itamae/recipe_children.rb
+++ b/lib/itamae/recipe_children.rb
@@ -57,7 +57,7 @@ module Itamae
       self.each do |resource|
         case resource
         when Resource::Base
-          resource.run(nil, dry_run: options[:dry_run])
+          resource.run
         when Recipe
           resource.run(options)
         end

--- a/lib/itamae/resource/base.rb
+++ b/lib/itamae/resource/base.rb
@@ -133,11 +133,11 @@ module Itamae
           end
 
           [specific_action || attributes.action].flatten.each do |action|
-            run_action(action, options)
+            run_action(action)
           end
 
-          verify unless options[:dry_run]
-          notify(options) if updated?
+          verify unless @options[:dry_run]
+          notify if updated?
         end
 
         @updated = false
@@ -166,7 +166,7 @@ module Itamae
 
       alias_method :current, :current_attributes
 
-      def run_action(action, options)
+      def run_action(action, options = {})
         @current_action = action
 
         clear_current_attributes
@@ -186,12 +186,12 @@ module Itamae
           show_differences
 
           method_name = "action_#{action}"
-          if options[:dry_run]
+          if @options[:dry_run]
             unless respond_to?(method_name)
               Logger.error "action #{action.inspect} is unavailable"
             end
           else
-            public_send(method_name, options)
+            public_send(method_name, @options)
           end
 
           updated! if different?
@@ -324,7 +324,7 @@ module Itamae
         @updated
       end
 
-      def notify(options)
+      def notify(options = {})
         (notifications + recipe.children.subscribing(self)).each do |notification|
           message = "Notifying #{notification.action} to #{notification.action_resource.resource_type} resource '#{notification.action_resource.resource_name}'"
 
@@ -343,7 +343,7 @@ module Itamae
           if notification.delayed?
             @recipe.delayed_notifications << notification
           elsif notification.immediately?
-            notification.run(options)
+            notification.run(@options)
           end
         end
       end

--- a/lib/itamae/resource/base.rb
+++ b/lib/itamae/resource/base.rb
@@ -100,10 +100,11 @@ module Itamae
       attr_reader :notifications
       attr_reader :updated
 
-      def initialize(recipe, resource_name, &block)
+      def initialize(recipe, resource_name, options = {}, &block)
         clear_current_attributes
         @recipe = recipe
         @resource_name = resource_name
+        @options = options
         @updated = false
 
         EvalContext.new(self).tap do |context|
@@ -360,4 +361,3 @@ module Itamae
     end
   end
 end
-

--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -20,9 +20,11 @@ module Itamae
         when :edit
           attributes.exist = true
 
-          content = backend.receive_file(attributes.path)
-          attributes.block.call(content)
-          attributes.content = content
+          unless @options[:dry_run]
+            content = backend.receive_file(attributes.path)
+            attributes.block.call(content)
+            attributes.content = content
+          end
         end
 
         send_tempfile
@@ -145,4 +147,3 @@ module Itamae
     end
   end
 end
-

--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -43,7 +43,7 @@ module Itamae
 
     def load_recipes(paths)
       paths.each do |path|
-        recipe = Recipe.new(self, File.expand_path(path))
+        recipe = Recipe.new(self, File.expand_path(path), @options)
         children << recipe
         recipe.load
       end
@@ -85,4 +85,3 @@ module Itamae
     end
   end
 end
-

--- a/spec/unit/lib/itamae/resource/base_spec.rb
+++ b/spec/unit/lib/itamae/resource/base_spec.rb
@@ -122,10 +122,12 @@ describe TestResource do
     end
 
     context 'with dry_run' do
+      subject(:dry_run_resource) { described_class.new(recipe, "name", dry_run: true) }
+
       context 'when specified action is unavailable' do
         it 'logs error' do
           expect(Itamae::Logger).to receive(:error).with(/action :name is unavailable/)
-          subject.run(nil, dry_run: true)
+          subject.run
         end
       end
     end


### PR DESCRIPTION
ref #136 

When `dry_run` mode, raise an error in `edit` action against a `file` resource if the target file does not exist.
So, I skip the method that raise an error to use `dry_run` options.

this is recipe.rb
```rb
file "./sample_file" do
  action :edit
end
```

Before apply this patch
```sh
ganmacs@ganmacs~% bundle exec bin/itamae ssh --vagrant recipe.rb --dry-run
 INFO : Starting Itamae...
 INFO : Recipe: /Users/ganmacs/src/github.com/ganmacs/itamae/recipe.rb
/Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/net-scp-1.2.1/lib/net/scp.rb:365:in `block (3 levels) in start_command': SCP did not finish successfully (1): scp: ./sample_file: No such file or directory (Net::SCP::Error)
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/net-ssh-2.9.2/lib/net/ssh/connection/channel.rb:591:in `call'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/net-ssh-2.9.2/lib/net/ssh/connection/channel.rb:591:in `do_close'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/net-ssh-2.9.2/lib/net/ssh/connection/session.rb:587:in `channel_close'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/net-ssh-2.9.2/lib/net/ssh/connection/session.rb:466:in `dispatch_incoming_packets'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/net-ssh-2.9.2/lib/net/ssh/connection/session.rb:222:in `preprocess'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/net-ssh-2.9.2/lib/net/ssh/connection/session.rb:206:in `process'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/net-ssh-2.9.2/lib/net/ssh/connection/session.rb:170:in `block in loop'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/net-ssh-2.9.2/lib/net/ssh/connection/session.rb:170:in `loop'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/net-ssh-2.9.2/lib/net/ssh/connection/session.rb:170:in `loop'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/net-ssh-2.9.2/lib/net/ssh/connection/channel.rb:269:in `wait'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/net-scp-1.2.1/lib/net/scp.rb:321:in `download!'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/ext/specinfra.rb:34:in `scp_download!'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/ext/specinfra.rb:23:in `receive_file'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/backend.rb:93:in `receive_file'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/resource/file.rb:23:in `pre_action'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/resource/base.rb:179:in `block in run_action'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/logger.rb:40:in `call'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/logger.rb:40:in `with_indent_if'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/resource/base.rb:177:in `run_action'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/resource/base.rb:135:in `block (2 levels) in run'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/resource/base.rb:134:in `each'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/resource/base.rb:134:in `block in run'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/logger.rb:40:in `call'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/logger.rb:40:in `with_indent_if'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/resource/base.rb:125:in `run'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/recipe_children.rb:60:in `block in run'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/recipe_children.rb:57:in `each'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/recipe_children.rb:57:in `run'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/recipe.rb:48:in `block in run'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/logger.rb:31:in `with_indent'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/recipe.rb:47:in `run'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/recipe_children.rb:62:in `block in run'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/recipe_children.rb:57:in `each'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/recipe_children.rb:57:in `run'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/runner.rb:53:in `run'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/runner.rb:23:in `run'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/lib/itamae/cli.rb:53:in `ssh'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /Users/ganmacs/src/github.com/ganmacs/itamae/vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from bin/itamae:4:in `<main>'
bundle exec bin/itamae ssh --vagrant recipe.rb --dry-run  5.10s user 0.95s system 92% cpu 6.558 total
```


After apply this patch
```sh
anmacs@ganmacs~% bundle exec bin/itamae ssh --vagrant recipe.rb --dry-run
 INFO : Starting Itamae...
 INFO : Recipe: /Users/ganmacs/src/github.com/ganmacs/itamae/recipe.rb
 INFO :   file[./sample_file] exist will change from 'false' to 'true'
bundle exec bin/itamae ssh --vagrant recipe.rb --dry-run  5.08s user 0.94s system 89% cpu 6.738 total
```

As above, after Apply this patch, if the target file does not exist, we can't detect an error In `dry_run`