### PR TITLE
Make `cwd` a common attribute. (idea by @tacahilo )

### DIFF
--- a/lib/itamae/resource/base.rb
+++ b/lib/itamae/resource/base.rb
@@ -91,6 +91,7 @@ module Itamae
 
       define_attribute :action, type: [Symbol, Array], required: true
       define_attribute :user, type: String
+      define_attribute :cwd, type: String
 
       attr_reader :recipe
       attr_reader :resource_name
@@ -286,6 +287,7 @@ module Itamae
         end
 
         args.last[:user] ||= attributes.user
+        args.last[:cwd]  ||= attributes.cwd
 
         backend.run_command(*args)
       end

--- a/lib/itamae/resource/execute.rb
+++ b/lib/itamae/resource/execute.rb
@@ -5,7 +5,6 @@ module Itamae
     class Execute < Base
       define_attribute :action, default: :run
       define_attribute :command, type: String, default_name: true
-      define_attribute :cwd, type: String
 
       def pre_action
         case @current_action
@@ -19,7 +18,7 @@ module Itamae
       end
 
       def action_run(options)
-        run_command(attributes.command, cwd: attributes.cwd)
+        run_command(attributes.command)
         updated!
       end
     end


### PR DESCRIPTION
`cwd` is now a common attribute that can be used in any resource.