### PR TITLE
When `user` attr is set, change directory to the home directory. (idea by @tacahilo)

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -176,6 +176,7 @@ module Itamae
 
         user = options[:user]
         if user
+          command = "cd ~#{Shellwords.escape(user)} ; #{command}"
           command = "sudo -H -u #{Shellwords.escape(user)} -- /bin/sh -c #{Shellwords.escape(command)}"
         end
 

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -116,7 +116,7 @@ end
 describe file('/tmp/created_by_itamae_user') do
   it { should be_file }
   it { should be_owned_by 'itamae' }
-  its(:content) { should eq('/home/itamae') }
+  its(:content) { should eq("/home/itamae\n/home/itamae") }
 end
 
 describe file('/tmp/created_in_default2') do

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -26,6 +26,12 @@ user "update itamae user" do
   shell '/bin/dash'
 end
 
+directory "/home/itamae" do
+  mode "755"
+  owner "itamae"
+  group "itamae"
+end
+
 user "create itamae2 user with create home directory" do
   username "itamae2"
   create_home true
@@ -218,7 +224,7 @@ end
 
 #####
 
-execute "echo -n $HOME > /tmp/created_by_itamae_user" do
+execute "echo -n \"$HOME\n$(pwd)\" > /tmp/created_by_itamae_user" do
   user "itamae"
 end
 


### PR DESCRIPTION
When `user` attr is set, try to change directory to the user's home directory.

- even if `cd` command fail, it will be ignored.
- directory specified by `cwd` will take precedence over this