### PR TITLE
Making plugins usable without Bundler

### DIFF
--- a/lib/itamae/recipe.rb
+++ b/lib/itamae/recipe.rb
@@ -15,8 +15,9 @@ module Itamae
         target += '.rb' if target !~ /\.rb$/
         plugin_name = recipe.split('::')[0]
 
+        gem_name = "itamae-plugin-recipe-#{plugin_name}"
         spec = Gem.loaded_specs.values.find do |spec|
-          spec.name == "itamae-plugin-recipe-#{plugin_name}"
+          spec.name == gem_name
         end
 
         return nil unless spec

--- a/lib/itamae/recipe.rb
+++ b/lib/itamae/recipe.rb
@@ -16,6 +16,10 @@ module Itamae
         plugin_name = recipe.split('::')[0]
 
         gem_name = "itamae-plugin-recipe-#{plugin_name}"
+        begin
+          gem gem_name
+        rescue LoadError
+        end
         spec = Gem.loaded_specs.values.find do |spec|
           spec.name == gem_name
         end


### PR DESCRIPTION
@ryotarai 
Hi,

I found that I cannot `include_recipe` out of Bundler environment, that is, if I installed Itamae and its plugins by `gem` command.

    % gem list itamae
    
    *** LOCAL GEMS ***
    
    itamae (1.4.1)
    itamae-plugin-recipe-selinux (0.0.5)
    % cat recipe.rb
    include_recipe 'selinux::disabled'
    % itamae local recipe.rb
     INFO : Starting Itamae...
    /home/ikeda/.gem/ruby/2.2.0/gems/itamae-1.4.1/lib/itamae/recipe.rb:111:in `include_recipe': Recipe not found. (selinux::disabled) (Itamae::Recipe::NotFoundError)
    	from /tmp/recipe.rb:1:in `load'
    	from /home/ikeda/.gem/ruby/2.2.0/gems/itamae-1.4.1/lib/itamae/recipe.rb:41:in `instance_eval'
    	from /home/ikeda/.gem/ruby/2.2.0/gems/itamae-1.4.1/lib/itamae/recipe.rb:41:in `load'
    	from /home/ikeda/.gem/ruby/2.2.0/gems/itamae-1.4.1/lib/itamae/runner.rb:48:in `block in load_recipes'
    	from /home/ikeda/.gem/ruby/2.2.0/gems/itamae-1.4.1/lib/itamae/runner.rb:45:in `each'
    	from /home/ikeda/.gem/ruby/2.2.0/gems/itamae-1.4.1/lib/itamae/runner.rb:45:in `load_recipes'
    	from /home/ikeda/.gem/ruby/2.2.0/gems/itamae-1.4.1/lib/itamae/runner.rb:13:in `run'
    	from /home/ikeda/.gem/ruby/2.2.0/gems/itamae-1.4.1/lib/itamae/cli.rb:28:in `local'
    	from /home/ikeda/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    	from /home/ikeda/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    	from /home/ikeda/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    	from /home/ikeda/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    	from /home/ikeda/.gem/ruby/2.2.0/gems/itamae-1.4.1/bin/itamae:4:in `<top (required)>'
    	from /home/ikeda/.gem/ruby/2.2.0/bin/itamae:23:in `load'
    	from /home/ikeda/.gem/ruby/2.2.0/bin/itamae:23:in `<main>'

I wrote patch to fix the problem and will send pull request. Could you consider to merge it?

Thanks.