### PR TITLE
Ignore yaml when the result is false

### DIFF
--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -78,7 +78,7 @@ module Itamae
       if @options[:node_yaml]
         path = File.expand_path(@options[:node_yaml])
         Itamae.logger.info "Loading node data from #{path}..."
-        hash.merge!(YAML.load(open(path)))
+        hash.merge!(YAML.load(open(path)) || {})
       end
 
       Node.new(hash, @backend)


### PR DESCRIPTION
Because YAML does not have a good way to write empty hash (I only know `YAML.load('{}') #=> {}`), I sometimes comment out all lines in node.yml.
But if node.yml has only comments, `YAML.load` returns false. It crashes with `hash.merge!(false)`.

```rb
YAML.load('# comment') #=> false
```

So I want to fallback `YAML.load` result to empty hash when it has only comments.