### PR TITLE
Allow `include_recipe` to omit rb extension

### DIFF
--- a/lib/itamae/recipe.rb
+++ b/lib/itamae/recipe.rb
@@ -118,10 +118,9 @@ module Itamae
 
       def include_recipe(target)
         expanded_path = ::File.expand_path(target, File.dirname(@recipe.path))
-        candidate_paths = [
-          ::Dir.exists?(expanded_path) ? ::File.join(expanded_path, "default.rb") : expanded_path,
-          Recipe.find_recipe_in_gem(target),
-        ].compact
+        expanded_path = ::File.join(expanded_path, 'default.rb') if ::Dir.exists?(expanded_path)
+        expanded_path.concat('.rb') unless expanded_path.end_with?('.rb')
+        candidate_paths = [expanded_path, Recipe.find_recipe_in_gem(target)].compact
         path = candidate_paths.find {|path| File.exist?(path) }
 
         unless path


### PR DESCRIPTION
Like ruby's built-in `require`, it would be convenient to abridge `.rb` extension.
With this change, you can include `foo.rb` recipe by both `include_recipe 'foo.rb'` and `include_recipe 'foo'`. So this is backward-compatible.