### PR TITLE
Allow `load_recipes` to load plugin recipes directly

### DIFF
--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -43,7 +43,13 @@ module Itamae
 
     def load_recipes(paths)
       paths.each do |path|
-        recipe = Recipe.new(self, File.expand_path(path))
+        expanded_path = File.expand_path(path)
+        if path.include?('::')
+          gem_path = Recipe.find_recipe_in_gem(path)
+          expanded_path = gem_path if gem_path
+        end
+
+        recipe = Recipe.new(self, expanded_path)
         children << recipe
         recipe.load
       end


### PR DESCRIPTION
If you want to apply only a plugin recipe, you have to write a recipes which has only `include_recipe 'foo::bar'`. But if you can load plugin recipes directly, you can easily try plugin recipes.

```bash
$ gem install itamae-plugin-recipe-foo
$ itamae local foo::bar
```