### PR TITLE
Fix not send notifies when file edited

### DIFF
--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -101,6 +101,11 @@ module Itamae
           run_command(['chown', '--reference', attributes.path, @temppath])
         end
 
+        unless check_command(["diff", "-q", @temppath, attributes.path])
+          # the file is modified
+          updated!
+        end
+
         run_specinfra(:move_file, @temppath, attributes.path)
       end
 

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -342,6 +342,11 @@ file '/tmp/file_edit_sample' do
   block do |content|
     content.gsub!('world', 'Itamae')
   end
+  notifies :run, "execute[echo 1 >> /tmp/file_edit_notifies]"
+end
+
+execute 'echo 1 >> /tmp/file_edit_notifies' do
+  action :nothing
 end
 
 ###


### PR DESCRIPTION
not sent notifies following example.

```
file "/path/to/file" do
  action :edit
  block do |content|
    content.gsub!("world", "Itamae")
  end
  notifies :run, "execute[echo 1 >> /tmp/file_edit_notifies]"
end
```