### PR TITLE
Fallback to autoload resource plugin

### DIFF
--- a/lib/itamae/resource.rb
+++ b/lib/itamae/resource.rb
@@ -34,8 +34,17 @@ module Itamae
           begin
             ::Itamae::Plugin::Resource.const_get(to_camel_case(method.to_s))
           rescue NameError
-            raise Error, "#{method} resource is missing."
+            autoload_plugin_resource(method)
           end
+        end
+      end
+
+      def autoload_plugin_resource(method)
+        begin
+          require "itamae/plugin/resource/#{method}"
+          ::Itamae::Plugin::Resource.const_get(to_camel_case(method.to_s))
+        rescue LoadError, NameError
+          raise Error, "#{method} resource is missing."
         end
       end
 


### PR DESCRIPTION
Like recipe plugin, I want to use resource plugin without calling `require`. If the resource plugin follows `bundle gem`'s naming convention, require path of `foo` resource should be `itamae/plugin/resource/#{foo}`.

This autoload does not happen if it is explicitly required, so this change is backword-compatible.