### PR TITLE
Optimize git resource for fixed revision

### DIFF
--- a/lib/itamae/resource/git.rb
+++ b/lib/itamae/resource/git.rb
@@ -33,13 +33,12 @@ module Itamae
           cmd << attributes.repository << attributes.destination
           run_command(cmd)
           new_repository = true
-        else
-          run_command_in_repo(['git', 'fetch', 'origin'])
         end
 
         target = if attributes.revision
                    get_revision(attributes.revision)
                  else
+                   fetch_origin!
                    run_command_in_repo("git ls-remote origin HEAD | cut -f1").stdout.strip
                  end
 
@@ -52,6 +51,7 @@ module Itamae
             deploy_old_created = true
           end
 
+          fetch_origin!
           run_command_in_repo(["git", "checkout", target, "-b", DEPLOY_BRANCH])
 
           if deploy_old_created
@@ -81,6 +81,12 @@ module Itamae
 
       def get_revision(branch)
         run_command_in_repo("git rev-list #{shell_escape(branch)} | head -n1").stdout.strip
+      end
+
+      def fetch_origin!
+        return if @origin_fetched
+        @origin_fetched = true
+        run_command_in_repo(['git', 'fetch', 'origin'])
       end
     end
   end


### PR DESCRIPTION
`git fetch origin` can be very slow. For example,

```bash
$ git remote -v
origin  github.com:rbenv/rbenv (fetch)
origin  github.com:rbenv/rbenv (push)
$ time git fetch origin
git fetch origin  0.02s user 0.02s system 0% cpu 3.285 total
```

So I want to skip `git fetch origin` if HEAD is the same as specified revision.
With this change, following recipe execution time is optimized from 4.14s to 1.20s.

```rb
git "/Users/takashi-kokubun/.rbenv" do
  repository "git://github.com/rbenv/rbenv.git"
  revision "20755cfc153dd0bf802524cbb313f834a59c0f30"
end
```