### PR TITLE
Require extension gems automatically

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,7 @@ group :test do
     gem 'growl'
   end
 end
+
+group :itamae_extensions do
+  gem "some_itamae_extension", path: File.expand_path("../spec/some_itamae_extension", __FILE__)
+end

--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -4,12 +4,15 @@ require 'yaml'
 
 module Itamae
   class Runner
+    EXTENSION_GEM_GROUP = :itamae_extensions
+
     class << self
       def run(recipe_files, backend_type, options)
         Itamae.logger.info "Starting Itamae..."
 
         backend = Backend.create(backend_type, options)
         runner = self.new(backend, options)
+        runner.load_extensions(EXTENSION_GEM_GROUP)
         runner.load_recipes(recipe_files)
         runner.run
       end
@@ -34,6 +37,11 @@ module Itamae
 
       @backend.run_command(["mkdir", "-p", @tmpdir])
       @backend.run_command(["chmod", "777", @tmpdir])
+    end
+
+    def load_extensions(group)
+      Itamae.logger.info "Loading extensions in #{group}..."
+      Bundler.require(group)
     end
 
     def load_recipes(paths)

--- a/spec/some_itamae_extension/lib/some_itamae_extension.rb
+++ b/spec/some_itamae_extension/lib/some_itamae_extension.rb
@@ -1,0 +1,6 @@
+module SomeItamaeExtension
+  def itamae_extended
+  end
+end
+
+Itamae::Runner.extend(SomeItamaeExtension)

--- a/spec/some_itamae_extension/some_itamae_extension.gemspec
+++ b/spec/some_itamae_extension/some_itamae_extension.gemspec
@@ -1,0 +1,15 @@
+# coding: utf-8
+Gem::Specification.new do |spec|
+  spec.name          = "some_itamae_extension"
+  spec.version       = "1.0.0"
+  spec.authors       = ["itamae"]
+  spec.email         = ["itamae"]
+
+  spec.summary       = %q{For Itamae extension auto requiring test}
+  spec.homepage      = "http://itamae.kitchen/"
+
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+end

--- a/spec/unit/lib/itamae/runner_spec.rb
+++ b/spec/unit/lib/itamae/runner_spec.rb
@@ -27,6 +27,11 @@ module Itamae
         end
         described_class.run(recipes, :local, {})
       end
+
+      it "require extensions automatically" do
+        described_class.run([], :local, {})
+        expect(described_class).to respond_to(:itamae_extended)
+      end
     end
   end
 end


### PR DESCRIPTION
Hi :laughing: 
This PR makes Itamae more hackable and eliminate `require` in your recipes.

For example, in the case when using [itamae-default_attributes](https://github.com/nownabe/itamae-default_attributes), currently recipes need following code:

```ruby
require "itamae/default_attributes"
```

This PR provide simple way. In Gemfile, use `:itamae_extensions` group:

```ruby
source "https://rubygems.org"

gem "itamae"

group :itamae_extensions do
  gem "itamae-default_attributes"
end
```

And recipes don't need `require` anymore. :yum: