### PR TITLE
Improve http_request resource to use net/http

### DIFF
--- a/lib/itamae/resource/http_request.rb
+++ b/lib/itamae/resource/http_request.rb
@@ -1,18 +1,52 @@
 require 'itamae'
-require 'open-uri'
+require 'uri'
+require 'net/http'
 
 module Itamae
   module Resource
     class HttpRequest < File
       UrlNotFoundError = Class.new(StandardError)
 
+      define_attribute :action, default: :get
       define_attribute :headers, type: Hash, default: {}
+      define_attribute :message, type: String, default: ""
       define_attribute :url, type: String, required: true
 
       def pre_action
-        attributes.content = open(attributes.url, attributes.headers).read
+        uri = URI.parse(attributes.url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true if uri.scheme == "https"
+
+        case attributes.action
+        when :delete, :get, :options
+          response = http.method(attributes.action).call(uri.request_uri, attributes.headers)
+        when :post, :put
+          response = http.method(attributes.action).call(uri.request_uri, attributes.message, attributes.headers)
+        end
+
+        attributes.content = response.body
 
         super
+      end
+
+      def action_delete(options)
+        action_create(options)
+      end
+
+      def action_get(options)
+        action_create(options)
+      end
+
+      def action_options(options)
+        action_create(options)
+      end
+
+      def action_post(options)
+        action_create(options)
+      end
+
+      def action_put(options)
+        action_create(options)
       end
     end
   end

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -75,6 +75,27 @@ describe file('/tmp/http_request.html') do
   its(:content) { should match(/"from": "itamae"/) }
 end
 
+describe file('/tmp/http_request_delete.html') do
+  it { should be_file }
+  its(:content) { should match(/"from": "itamae"/) }
+end
+
+describe file('/tmp/http_request_post.html') do
+  it { should be_file }
+  its(:content) do
+    should match(/"from": "itamae"/)
+    should match(/"love": "sushi"/)
+  end
+end
+
+describe file('/tmp/http_request_put.html') do
+  it { should be_file }
+  its(:content) do
+    should match(/"from": "itamae"/)
+    should match(/"love": "sushi"/)
+  end
+end
+
 describe file('/tmp/http_request_headers.html') do
   it { should be_file }
   its(:content) { should match(/"User-Agent": "Itamae"/) }

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -160,6 +160,23 @@ http_request "/tmp/http_request.html" do
   url "https://httpbin.org/get?from=itamae"
 end
 
+http_request "/tmp/http_request_delete.html" do
+  action :delete
+  url "https://httpbin.org/delete?from=itamae"
+end
+
+http_request "/tmp/http_request_post.html" do
+  action :post
+  message "love=sushi"
+  url "https://httpbin.org/post?from=itamae"
+end
+
+http_request "/tmp/http_request_put.html" do
+  action :put
+  message "love=sushi"
+  url "https://httpbin.org/put?from=itamae"
+end
+
 http_request "/tmp/http_request_headers.html" do
   headers "User-Agent" => "Itamae"
   url "https://httpbin.org/get"


### PR DESCRIPTION
Use `net/http` on http_request resource to available DELETE. OPTIONS, POST and PUT as `action` .
And `message` that is sent by the HTTP request can be set when POST and PUT.
(Those features are same as [http_request](https://docs.chef.io/resource_http_request.html#actions) of Chef.)

For example:

```ruby
http_request "/tmp/http_request_post.html" do
  action :post
  message "love=sushi"
  url "https://httpbin.org/post?from=itamae"
end
```

However, the test of `action :options` is not yet added.
([httpbin](https://httpbin.org) does not support OPTIONS.)
