### PR TITLE
Add options attribute to gem_package resource

### DIFF
--- a/lib/itamae/resource/gem_package.rb
+++ b/lib/itamae/resource/gem_package.rb
@@ -6,6 +6,7 @@ module Itamae
       define_attribute :action, default: :install
       define_attribute :package_name, type: String, default_name: true
       define_attribute :gem_binary, type: [String, Array], default: 'gem'
+      define_attribute :options, type: [String, Array], default: []
       define_attribute :version, type: String
       define_attribute :source, type: String
 
@@ -64,7 +65,7 @@ module Itamae
       end
 
       def install!
-        cmd = [*Array(attributes.gem_binary), 'install']
+        cmd = [*Array(attributes.gem_binary), 'install', *Array(attributes.options)]
         if attributes.version
           cmd << '-v' << attributes.version
         end
@@ -78,4 +79,3 @@ module Itamae
     end
   end
 end
-

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -171,6 +171,10 @@ describe command('gem list') do
   its(:stdout) { should include('tzinfo (1.2.2, 1.1.0)') }
 end
 
+describe command('ri Bundler') do
+  its(:stderr) { should eq("Nothing known about Bundler\n") }
+end
+
 describe file('/tmp/created_by_definition') do
   it { should be_file }
   its(:content) { should eq("name:name,key:value,message:Hello, Itamae\n") }

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -65,6 +65,10 @@ gem_package 'tzinfo' do
   version '1.2.2'
 end
 
+gem_package 'bundler' do
+  options ['--no-ri', '--no-rdoc']
+end
+
 ######
 
 execute "echo -n > /tmp/notifies"


### PR DESCRIPTION
Add `options` attribute to `gem_package`.
(This attribute is same as [gem_package](https://docs.chef.io/resource_gem_package.html#properties) of Chef.)

For example:

```ruby
gem_package 'bundler' do
  options ['--no-ri', '--no-rdoc']
end
```