### PR TITLE
Fix bundler version error

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -238,7 +238,13 @@ module Itamae
         if @options[:vagrant]
           config = Tempfile.new('', Dir.tmpdir)
           hostname = opts[:host_name] || 'default'
-          `vagrant ssh-config #{hostname} > #{config.path}`
+          if defined?(Bundler)
+            Bundler.with_clean_env do
+              `vagrant ssh-config #{hostname} > #{config.path}`
+            end
+          else
+            `vagrant ssh-config #{hostname} > #{config.path}`
+          end
           opts.merge!(Net::SSH::Config.for(hostname, [config.path]))
         end
 

--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -238,12 +238,13 @@ module Itamae
         if @options[:vagrant]
           config = Tempfile.new('', Dir.tmpdir)
           hostname = opts[:host_name] || 'default'
+          vagrant_cmd = "vagrant ssh-config #{hostname} > #{config.path}"
           if defined?(Bundler)
             Bundler.with_clean_env do
-              `vagrant ssh-config #{hostname} > #{config.path}`
+              `#{vagrant_cmd}`
             end
           else
-            `vagrant ssh-config #{hostname} > #{config.path}`
+            `#{vagrant_cmd}`
           end
           opts.merge!(Net::SSH::Config.for(hostname, [config.path]))
         end


### PR DESCRIPTION
Vagrant relies on some internal APIs in Bundler core. 
The command of `bundle
exec itamae ssh --vagrant` will conflict with Vagrant APIs.

Using `Bundler.with_clean_env` is necessary when using itamae with bundler.

* ref:
 * #185
 * https://github.com/mitchellh/vagrant/issues/5581#issuecomment-91889166