### PR TITLE
Fix to use specinfra to avoid calling direct command.

### DIFF
--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -94,15 +94,15 @@ module Itamae
         if attributes.mode
           run_specinfra(:change_file_mode, @temppath, attributes.mode)
         else
-          mode=run_specinfra(:get_file_mode, attributes.path).stdout.chomp
+          mode = run_specinfra(:get_file_mode, attributes.path).stdout.chomp
           run_specinfra(:change_file_mode, @temppath, mode)
         end
 
         if attributes.owner || attributes.group
           run_specinfra(:change_file_owner, @temppath, attributes.owner, attributes.group)
         else
-          owner=run_specinfra(:get_file_owner_user, attributes.path).stdout.chomp
-          group=run_specinfra(:get_file_owner_group, attributes.path).stdout.chomp
+          owner = run_specinfra(:get_file_owner_user, attributes.path).stdout.chomp
+          group = run_specinfra(:get_file_owner_group, attributes.path).stdout.chomp
           run_specinfra(:change_file_owner, @temppath, owner)
           run_specinfra(:change_file_group, @temppath, group)
         end

--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -94,13 +94,17 @@ module Itamae
         if attributes.mode
           run_specinfra(:change_file_mode, @temppath, attributes.mode)
         else
-          run_command(['chmod', '--reference', attributes.path, @temppath])
+          mode=run_specinfra(:get_file_mode, attributes.path)
+          run_specinfra(:change_file_mode, @temppath, mode.stdout.chomp)
         end
 
         if attributes.owner || attributes.group
           run_specinfra(:change_file_owner, @temppath, attributes.owner, attributes.group)
         else
-          run_command(['chown', '--reference', attributes.path, @temppath])
+          owner=run_specinfra(:get_file_owner_user, attributes.path).stdout.chomp
+          group=run_specinfra(:get_file_owner_group, attributes.path).stdout.chomp
+          run_specinfra(:change_file_owner, @temppath, owner)
+          run_specinfra(:change_file_group, @temppath, group)
         end
 
         unless check_command(["diff", "-q", @temppath, attributes.path])

--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -94,8 +94,8 @@ module Itamae
         if attributes.mode
           run_specinfra(:change_file_mode, @temppath, attributes.mode)
         else
-          mode=run_specinfra(:get_file_mode, attributes.path)
-          run_specinfra(:change_file_mode, @temppath, mode.stdout.chomp)
+          mode=run_specinfra(:get_file_mode, attributes.path).stdout.chomp
+          run_specinfra(:change_file_mode, @temppath, mode)
         end
 
         if attributes.owner || attributes.group


### PR DESCRIPTION
For FreeBSD, 'chown --reference' and 'chmod --reference' are not supported.
Itamae should use the interfaces which specinfra supports.