### PR TITLE
Don't replace files when they will not be updated

### DIFF
--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -80,7 +80,9 @@ module Itamae
             updated!
           end
 
-          run_specinfra(:move_file, @temppath, attributes.path)
+          if updated?
+            run_specinfra(:move_file, @temppath, attributes.path)
+          end
         end
       end
 


### PR DESCRIPTION
Hi,

Updating files only when their contents will be updated is nice idea. I wrote patch for that.
Need I write test? If yes, we need to run test before and after running Itamae and it look over the top to me. That's why this pull request doesn't include test.

Background of this patch is:
I defined `notifies` to execute `restorecon` to `file` and `template` resources. But current Itamae doesn't kick `notifies` if contents of files are not updated in spite of the files are replaced with files whose contents are the same and SELinux security contexts are changed. If this patch is applied, Itamae doesn't touch files if they will not be updated, so security context will not be changed.

Could you consider the request?
Thanks.