### PR TITLE
Accept any objects as a log message

### DIFF
--- a/lib/itamae/logger.rb
+++ b/lib/itamae/logger.rb
@@ -48,9 +48,24 @@ module Itamae
       %w!debug info warn error fatal unknown!.each do |level|
         module_eval(<<-EOC, __FILE__, __LINE__ + 1)
           def #{level}(msg)
-            super("  " * indent_depth + msg)
+            super(indent_msg(msg))
           end
         EOC
+      end
+
+      private
+
+      def indent_msg(msg)
+        spaces = "  " * indent_depth
+        case msg
+        when ::String
+          "#{spaces}#{msg}"
+        when ::Exception
+          "#{spaces}#{msg.message} (#{msg.class})\n" <<
+          (msg.backtrace || []).map {|f| "#{spaces}#{f}"}.join("\n")
+        else
+          "#{spaces}#{msg.inspect}"
+        end
       end
     end
 

--- a/spec/unit/lib/itamae/logger_spec.rb
+++ b/spec/unit/lib/itamae/logger_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+module Itamae
+  describe Logger do
+    describe "#debug" do
+      context "`msg` is a String" do
+        it "indents the message" do
+          expect_any_instance_of(::Logger).to receive(:debug).with("  msg")
+          Itamae.logger.with_indent do
+            Itamae.logger.debug("msg")
+          end
+        end
+      end
+
+      context "`msg` is an Exception" do
+        let(:msg) { ::Exception.new("error") }
+
+        before do
+          allow(msg).to receive(:backtrace) { %w!frame1 frame2! }
+        end
+
+        it "indents the error message and the backtrace" do
+          expect_any_instance_of(::Logger).to receive(:debug).with(<<-MSG.rstrip)
+  error (Exception)
+  frame1
+  frame2
+          MSG
+          Itamae.logger.with_indent do
+            Itamae.logger.debug(msg)
+          end
+        end
+      end
+
+      context "`msg` is an Array" do
+        it "indents the message" do
+          expect_any_instance_of(::Logger).to receive(:debug).with("  []")
+          Itamae.logger.with_indent do
+            Itamae.logger.debug([])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request fix an error like below:

```
% itamae docker --image ubuntu recipe.rb
 INFO : Starting Itamae...
/Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/itamae-1.9.2/lib/itamae/logger.rb:51:in `+': no implicit conversion of Array into String (TypeError)
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/itamae-1.9.2/lib/itamae/logger.rb:51:in `debug'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/docker-api-1.26.0/lib/docker/connection.rb:57:in `log_request'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/docker-api-1.26.0/lib/docker/connection.rb:39:in `request'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/docker-api-1.26.0/lib/docker/connection.rb:65:in `block (2 levels) in <class:Connection>'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/docker-api-1.26.0/lib/docker/image.rb:126:in `get'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/specinfra-2.50.3/lib/specinfra/backend/docker.rb:106:in `get_or_pull_image'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/specinfra-2.50.3/lib/specinfra/backend/docker.rb:17:in `initialize'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/itamae-1.9.2/lib/itamae/backend.rb:285:in `new'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/itamae-1.9.2/lib/itamae/backend.rb:285:in `create_specinfra_backend'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/itamae-1.9.2/lib/itamae/backend.rb:42:in `initialize'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/itamae-1.9.2/lib/itamae/backend.rb:33:in `new'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/itamae-1.9.2/lib/itamae/backend.rb:33:in `create'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/itamae-1.9.2/lib/itamae/runner.rb:11:in `run'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/itamae-1.9.2/lib/itamae/cli.rb:70:in `docker'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/itamae-1.9.2/bin/itamae:4:in `<top (required)>'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/bin/itamae:23:in `load'
        from /Users/arabiki/.anyenv/envs/rbenv/versions/2.3.0/bin/itamae:23:in `<main>'
```

This error occurs by passing non-string argument to `Itamae::Logger#debug`.
cf. https://github.com/swipely/docker-api/blob/v1.26.0/lib/docker/connection.rb#L57-L59