### PR TITLE
Delete 'deploy-old' branch forcibly in action_sync

### DIFF
--- a/lib/itamae/resource/git.rb
+++ b/lib/itamae/resource/git.rb
@@ -55,7 +55,7 @@ module Itamae
           run_command_in_repo(["git", "checkout", target, "-b", DEPLOY_BRANCH])
 
           if deploy_old_created
-            run_command_in_repo("git branch -d deploy-old")
+            run_command_in_repo("git branch -D deploy-old")
           end
         end
       end


### PR DESCRIPTION
'git branch -d <branch>' deletes the fully merged branch only.
But 'deploy-old' isn't merged in its upstream branch.
Therefore, it can not be deleted.