### PR TITLE
Fix a bug that displays inappropriate diff in file deletion

### DIFF
--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -50,7 +50,7 @@ module Itamae
 
         super
 
-        if @temppath
+        if @temppath && @current_action != :delete
           compare_file
         end
       end

--- a/lib/itamae/resource/template.rb
+++ b/lib/itamae/resource/template.rb
@@ -16,14 +16,7 @@ module Itamae
       private
 
       def content_file
-        if @current_action == :delete
-          f = Tempfile.open('itamae')
-          f.write(nil)
-          f.close
-          f.path
-        else
-          nil
-        end
+        nil
       end
 
       def source_file_dir

--- a/lib/itamae/resource/template.rb
+++ b/lib/itamae/resource/template.rb
@@ -16,7 +16,14 @@ module Itamae
       private
 
       def content_file
-        nil
+        if @current_action == :delete
+          f = Tempfile.open('itamae')
+          f.write(nil)
+          f.close
+          f.path
+        else
+          nil
+        end
       end
 
       def source_file_dir


### PR DESCRIPTION
It seems that `template` resource's `:delete` action doesn't work as what I suppose. It always displays contents of its source. I think itamae should suppress diff in `:delete` action like below.

### before

```
itamae local bootstrap.rb
 INFO : Starting Itamae...
 INFO : Recipe: /opt/itamae/bootstrap.rb
 INFO :   Recipe: /opt/itamae/cookbooks/java/tomcat.rb
 INFO :     template[/usr/share/tomcat7/newrelic/newrelic.yml] exist will change from 'true' to 'false'
 INFO :     diff:
 INFO :     --- /usr/share/tomcat7/newrelic/newrelic.yml        2016-02-17 11:12:18.541089617 +0000
 INFO :     +++ /tmp/itamae_tmp/1455707545.4180827      2016-02-17 11:12:25.413097913 +0000
 INFO :     @@ -0,0 +1,277 @@
 INFO :     +# This file configures the New Relic Agent.  New Relic monitors
 INFO :     +# Java applications with deep visibility and low overhead.  For more details and additional
 INFO :     +# configuration options visit https://docs.newrelic.com/docs/java/java-agent-configuration.
....
```

### after

```
itamae local bootstrap.rb
 INFO : Starting Itamae...
 INFO : Recipe: /opt/itamae/bootstrap.rb
 INFO :   Recipe: /opt/itamae/cookbooks/java/tomcat.rb
 INFO :     template[/usr/share/tomcat7/newrelic/newrelic.yml] exist will change from 'true' to 'false'
...
```

Although this code passes tests, I'm not sure this is a good way to suppress inappropriate diff. Plz give me feedback if you guys have good ideas.