### PR TITLE
add definition resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 .vagrant
 Gemfile.local
+vendor/bundle

--- a/lib/itamae/resource.rb
+++ b/lib/itamae/resource.rb
@@ -15,6 +15,7 @@ require 'itamae/resource/git'
 require 'itamae/resource/user'
 require 'itamae/resource/group'
 require 'itamae/resource/gem_package'
+require 'itamae/resource/definition'
 
 module Itamae
   module Resource

--- a/lib/itamae/resource/definition.rb
+++ b/lib/itamae/resource/definition.rb
@@ -1,0 +1,39 @@
+require 'itamae/resource/base'
+
+module Itamae
+  module Resource
+    class Definition < Base
+      class << self
+        def definition_block
+          value = class_variable_get(:@@definition_block) if class_variable_defined?(:@@definition_block)
+          value
+        end
+
+        def definition_block=(value)
+          class_variable_set(:@@definition_block, value)
+        end
+
+        def define_resource(&block)
+          self.definition_block = block
+        end
+      end
+
+      def initialize(*args)
+        super
+
+        r = Recipe::RecipeFromDefinition.new(
+          runner,
+          recipe.path,
+        )
+        recipe.children << r
+
+        r.definition = self
+        r.load(params: @attributes.merge(name: resource_name))
+      end
+
+      def run(*args)
+        # nothing
+      end
+    end
+  end
+end

--- a/spec/unit/lib/itamae/resource/definition_spec.rb
+++ b/spec/unit/lib/itamae/resource/definition_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'itamae'
+
+class DefineDefinitionTestResource < Itamae::Resource::Definition
+  define_attribute :action, default: :create
+
+  def self.dir
+    @@dir
+  end
+
+  def self.dir=(dir)
+    @@dir = dir
+  end
+
+  define_resource do
+    file "#{DefineDefinitionTestResource.dir}/foo.txt" do
+      content "bar"
+    end
+  end
+end
+
+
+describe DefineDefinitionTestResource do
+  let(:backend) { Itamae::Backend.create(:local, {}) }
+  let(:runner) { Itamae::Runner.new(backend, {}) }
+  let(:recipe) do
+    double(
+      :recipe,
+      runner: runner,
+      path: File.expand_path("recipe1.rb"),
+      children: runner.children)
+  end
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      DefineDefinitionTestResource.dir = dir
+      Dir.chdir(dir) do
+        example.run
+      end
+    end
+  end
+
+  before do
+    described_class.new(recipe, 'definition resource')
+  end
+
+  it "" do
+    runner.run
+    expect(File.exist?(File.expand_path("foo.txt"))).to be_truthy
+  end
+end

--- a/spec/unit/lib/itamae/runner_spec.rb
+++ b/spec/unit/lib/itamae/runner_spec.rb
@@ -16,9 +16,8 @@ module Itamae
     describe ".run" do
       let(:recipes) { %w! ./recipe1.rb ./recipe2.rb ! }
       it "runs each recipe with the runner" do
-        pending "Rewrite later"
         recipes.each do |r|
-          recipe = double(:recipe)
+          recipe = double(:recipe, load: nil)
           allow(Recipe).to receive(:new).with(
             an_instance_of(Itamae::Runner),
             File.expand_path(r)


### PR DESCRIPTION
### Brief Description

This PR adds a fuctionality to define recipe as a resource.

### How to Use

```ruby
class InstallMongodb < ::Itamae::Resource::Definition
  define_attribute :action, default: :install

  define_resource do
    file '/etc/yum.repos.d/mongodb-org-3.2.repo' do
      owner 'root'
      group 'root'
      mode '644'
      content <<-EOS.gsub(/^\s+/, '')
      [mongodb-org-3.2]
      name=MongoDB Repository
      baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/x86_64/
      gpgcheck=0
      enabled=1
      EOS
    end

    package 'mongodb-org' do
      version attributes[:name] if attributes[:name]
      action :install
    end

    service 'mongod' do
      action [:enable, :start]
    end
  end
end
```
