### PR TITLE
plugin initialization support and pre-load recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 .vagrant
 Gemfile.local
+vendor/bundle

--- a/lib/itamae.rb
+++ b/lib/itamae.rb
@@ -1,4 +1,5 @@
 require "itamae/version"
+require "itamae/configuration"
 require "itamae/runner"
 require "itamae/cli"
 require "itamae/recipe"

--- a/lib/itamae/configuration.rb
+++ b/lib/itamae/configuration.rb
@@ -1,0 +1,51 @@
+module Itamae
+  class Configuration
+    def initialize
+      @logger = ::Logger.new($stdout).tap do |l|
+        l.formatter = Itamae::Logger::Formatter.new
+      end.extend(Itamae::Logger::Helper)
+    end
+
+    def logger
+      @logger
+    end
+
+    def logger=(l)
+      @logger = l.extend(Itamae::Logger::Helper)
+    end
+
+    def default_recipes
+      @default_recipes ||= []
+    end
+
+    def add_recipe(path)
+      default_recipes << path
+    end
+
+    def prepend_recipe(path)
+      default_recipes.unshift path
+    end
+  end
+
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configuration=(value)
+      @configuration = value
+    end
+
+    def configure(&blokc)
+      configuration.instance_eval &block
+    end
+
+    def logger
+      configuration.logger
+    end
+
+    def logger=(l)
+      configuration.logger = l
+    end
+  end
+end

--- a/lib/itamae/logger.rb
+++ b/lib/itamae/logger.rb
@@ -107,18 +107,4 @@ module Itamae
       end
     end
   end
-
-  @logger = ::Logger.new($stdout).tap do |l|
-    l.formatter = Itamae::Logger::Formatter.new
-  end.extend(Itamae::Logger::Helper)
-
-  class << self
-    def logger
-      @logger
-    end
-
-    def logger=(l)
-      @logger = l.extend(Itamae::Logger::Helper)
-    end
-  end
 end

--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -8,6 +8,16 @@ module Itamae
       def run(recipe_files, backend_type, options)
         Itamae.logger.info "Starting Itamae..."
 
+        # give a chance to initialize the plugin
+        Gem.loaded_specs.values.each do |spec|
+          next unless spec.name.start_with?('itamae-plugin-')
+
+          begin
+            require spec.name
+          rescue LoadError
+          end
+        end
+
         backend = Backend.create(backend_type, options)
         runner = self.new(backend, options)
         runner.load_recipes(recipe_files)

--- a/spec/unit/lib/itamae/runner_spec.rb
+++ b/spec/unit/lib/itamae/runner_spec.rb
@@ -16,9 +16,8 @@ module Itamae
     describe ".run" do
       let(:recipes) { %w! ./recipe1.rb ./recipe2.rb ! }
       it "runs each recipe with the runner" do
-        pending "Rewrite later"
         recipes.each do |r|
-          recipe = double(:recipe)
+          recipe = double(:recipe, load: nil)
           allow(Recipe).to receive(:new).with(
             an_instance_of(Itamae::Runner),
             File.expand_path(r)


### PR DESCRIPTION
## Brief Description

This PR gives a chance to initialize plugin.
And also this PR pre-loads recipes before running recipes.

## How to Use

File `itamae-plugin-resource-xxx.rb` which initializes plugin looks like.

```ruby
Itamae.configure do |config|
  config.add_recipe ::File.expand_path('itamae/plugin/recipe/recipe1.rb', ::File.dirname(__FILE__))
  config.add_recipe ::File.expand_path('itamae/plugin/recipe/recipe2.rb', ::File.dirname(__FILE__))
  ...
end
```

`xxx` is a resource name and `xxx` resource plugin provides not only resources but also recipes.

File `recipe1.rb` looks like:

```
define :install_mongodb do
  file '/etc/yum.repos.d/mongodb-org-3.2.repo' do
    owner 'root'
    group 'root'
    mode '644'
    content <<-EOS.gsub(/^\s+/, '')
    [mongodb-org-3.2]
    name=MongoDB Repository
    baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/x86_64/
    gpgcheck=0
    enabled=1
    EOS
  end

  package 'mongodb-org' do
    version attributes[:name] if attributes[:name]
    action :install
  end

  service 'mongod' do
    action [:enable, :start]
  end
end
```
