### PR TITLE
Introduce --detailed-exitcode option.

### DIFF
--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -24,6 +24,7 @@ module Itamae
       option :shell, type: :string, default: "/bin/sh"
       option :ohai, type: :boolean, default: false, desc: "This option is DEPRECATED and will be unavailable."
       option :profile, type: :string, desc: "[EXPERIMENTAL] Save profiling data", banner: "PATH"
+      option :detailed_exitcode, type: :boolean, default: false, desc: "Exit code 0 means succeeded and no diff, 1 means errored, and 2 means succeeded and there is a diff"
     end
 
     desc "local RECIPE [RECIPE...]", "Run Itamae locally"
@@ -33,7 +34,7 @@ module Itamae
         raise "Please specify recipe files."
       end
 
-      Runner.run(recipe_files, :local, options)
+      run(recipe_files, :local, options)
     end
 
     desc "ssh RECIPE [RECIPE...]", "Run Itamae via ssh"
@@ -54,7 +55,7 @@ module Itamae
         raise "Please set '-h <hostname>' or '--vagrant'"
       end
 
-      Runner.run(recipe_files, :ssh, options)
+      run(recipe_files, :ssh, options)
     end
 
     desc "docker RECIPE [RECIPE...]", "Create Docker image"
@@ -67,7 +68,7 @@ module Itamae
         raise "Please specify recipe files."
       end
 
-      Runner.run(recipe_files, :docker, options)
+      run(recipe_files, :docker, options)
     end
 
     desc "version", "Print version"
@@ -116,6 +117,13 @@ module Itamae
         msg = %Q!ERROR: "itamae #{command}" was called with "#{target}" !
         msg << "but expected to be in #{GENERATE_TARGETS.inspect}"
         fail InvocationError, msg
+      end
+    end
+
+    def run(recipe_files, backend_type, options)
+      runner = Runner.run(recipe_files, backend_type, options)
+      if options[:detailed_exitcode] && runner.diff?
+        exit 2
       end
     end
   end

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -24,7 +24,7 @@ module Itamae
       option :shell, type: :string, default: "/bin/sh"
       option :ohai, type: :boolean, default: false, desc: "This option is DEPRECATED and will be unavailable."
       option :profile, type: :string, desc: "[EXPERIMENTAL] Save profiling data", banner: "PATH"
-      option :detailed_exitcode, type: :boolean, default: false, desc: "Exit code 0 means succeeded and no diff, 1 means errored, and 2 means succeeded and there is a diff"
+      option :detailed_exitcode, type: :boolean, default: false, desc: "exit code 0 - The run succeeded with no changes or failures, exit code 1 - The run failed, exit code 2 - The run succeeded, and some resources were changed"
     end
 
     desc "local RECIPE [RECIPE...]", "Run Itamae locally"

--- a/lib/itamae/resource/base.rb
+++ b/lib/itamae/resource/base.rb
@@ -139,6 +139,7 @@ module Itamae
 
             verify unless runner.dry_run?
             if updated?
+              runner.diff_found!
               notify
               runner.handler.event(:resource_updated)
             end

--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -12,6 +12,8 @@ module Itamae
         runner = self.new(backend, options)
         runner.load_recipes(recipe_files)
         runner.run
+
+        runner
       end
     end
 
@@ -31,6 +33,7 @@ module Itamae
       @node = create_node
       @tmpdir = "/tmp/itamae_tmp"
       @children = RecipeChildren.new
+      @diff = false
 
       @backend.run_command(["mkdir", "-p", @tmpdir])
       @backend.run_command(["chmod", "777", @tmpdir])
@@ -78,6 +81,14 @@ module Itamae
       open(path, 'w', 0600) do |f|
         f.write(@backend.executed_commands.to_json)
       end
+    end
+
+    def diff?
+      @diff
+    end
+
+    def diff_found!
+      @diff = true
     end
 
     private


### PR DESCRIPTION
It is useful for automation of Itamae.

- 0 - succeeded and no diff
- 1 - failed
- 2 - succeeded and there is a diff