### PR TITLE
Add `--ssh-config` option to `itamae ssh` to specify ssh_config

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -230,7 +230,8 @@ module Itamae
         opts[:host_name] = @options[:host]
 
         # from ssh-config
-        opts.merge!(Net::SSH::Config.for(@options[:host]))
+        ssh_config_files = @options[:ssh_config] ? [@options[:ssh_config]] : Net::SSH::Config.default_files
+        opts.merge!(Net::SSH::Config.for(@options[:host], ssh_config_files))
         opts[:user] = @options[:user] || opts[:user] || Etc.getlogin
         opts[:keys] = [@options[:key]] if @options[:key]
         opts[:port] = @options[:port] if @options[:port]

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -43,6 +43,7 @@ module Itamae
     option :user, type: :string, aliases: ['-u']
     option :key, type: :string, aliases: ['-i']
     option :port, type: :numeric, aliases: ['-p']
+    option :ssh_config, type: :string, aliases: ['-F']
     option :vagrant, type: :boolean, default: false
     option :ask_password, type: :boolean, default: false
     option :sudo, type: :boolean, default: true

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -43,7 +43,7 @@ module Itamae
     option :user, type: :string, aliases: ['-u']
     option :key, type: :string, aliases: ['-i']
     option :port, type: :numeric, aliases: ['-p']
-    option :ssh_config, type: :string, aliases: ['-F']
+    option :ssh_config, type: :string
     option :vagrant, type: :boolean, default: false
     option :ask_password, type: :boolean, default: false
     option :sudo, type: :boolean, default: true

--- a/spec/unit/lib/itamae/backend_spec.rb
+++ b/spec/unit/lib/itamae/backend_spec.rb
@@ -73,6 +73,26 @@ module Itamae
           let(:options) { {host: host_name} }
           it { is_expected.to eq( default_option.merge({host_name: host_name}) ) }
         end
+
+        context "with ssh_config option" do
+          around do |example|
+            Tempfile.create("ssh_config") do |temp|
+              temp.write(<<EOF)
+Host ex1
+  HostName example.com
+  User myname
+  Port 10022
+EOF
+              temp.flush
+              @ssh_config = temp.path
+              example.run
+            end
+          end
+
+          let(:options) { {host: "ex1", ssh_config: @ssh_config} }
+
+          it { is_expected.to a_hash_including({host_name: "example.com", user: "myname", port: 10022}) }
+        end
       end
 
       describe "#disable_sudo?" do


### PR DESCRIPTION
I need `-F` option like SSH to specify alternative ssh_config file.

```
$ itamae ssh --ssh-config .ssh/development -h devhost -y nodes/web.yml roles/web.rb
```