### PR TITLE
Fix url in gemspec and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $ bundle exec rake spec
 
 ## Contributing
 
-If you have a problem, please [create an issue](https://github.com/ryotarai/itamae/issues/new) or a pull request.
+If you have a problem, please [create an issue](https://github.com/itamae-kitchen/itamae/issues/new) or a pull request.
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)

--- a/itamae.gemspec
+++ b/itamae.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Ryota Arai"]
   spec.email         = ["ryota.arai@gmail.com"]
   spec.summary       = %q{Simple Configuration Management Tool}
-  spec.homepage      = "https://github.com/ryotarai/itamae"
+  spec.homepage      = "https://github.com/itamae-kitchen/itamae"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
`spec.homepage` is used in https://rubygems.org/gems/itamae

This is link to https://github.com/ryotarai/itamae 

![2016-06-02 23 35 52](https://cloud.githubusercontent.com/assets/608755/15748728/e9263d1e-291a-11e6-9f19-cfd7e9e12482.png)



By the way, codeclimate link in README.md is old
https://codeclimate.com/github/ryotarai/itamae is not been updated

i recommend to replace to new one.