### PR TITLE
send_file failed against docker backend

### DIFF
--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -174,9 +174,16 @@ module Itamae
 
           @temppath = ::File.join(runner.tmpdir, Time.now.to_f.to_s)
 
-          run_command(["touch", @temppath])
-          run_specinfra(:change_file_mode, @temppath, '0600')
-          backend.send_file(src, @temppath)
+          if backend.is_a?(Itamae::Backend::Docker)
+            run_command(["mkdir", @temppath])
+            backend.send_file(src, @temppath)
+            @temppath = ::File.join(@temppath, ::File.basename(src))
+          else
+            run_command(["touch", @temppath])
+            run_specinfra(:change_file_mode, @temppath, '0600')
+            backend.send_file(src, @temppath)
+          end
+
           run_specinfra(:change_file_mode, @temppath, '0600')
         ensure
           f.unlink if f


### PR DESCRIPTION
There is a problem that sending file is failed when the backend is docker. Reproduciton code is [here](https://github.com/Joe-noh/cannot_send_file).

This PR fixes the problem. Docker backend needs second argument for `send_file` to be a directory path. but I'm not sure this changes are good solution for the problem. please give me an advice if you find any other way to solve it.

Thanks.