### PR TITLE
Add uninstall action to gem_package

### DIFF
--- a/lib/itamae/resource/gem_package.rb
+++ b/lib/itamae/resource/gem_package.rb
@@ -46,10 +46,7 @@ module Itamae
       end
 
       def action_uninstall(action_options)
-        if current.installed
-          uninstall!
-          updated!
-        end
+        uninstall! if current.installed
       end
 
       def action_upgrade(action_options)

--- a/lib/itamae/resource/gem_package.rb
+++ b/lib/itamae/resource/gem_package.rb
@@ -14,6 +14,8 @@ module Itamae
         case @current_action
         when :install
           attributes.installed = true
+        when :uninstall
+          attributes.installed = false
         end
       end
 
@@ -39,6 +41,13 @@ module Itamae
           end
         else
           install!
+          updated!
+        end
+      end
+
+      def action_uninstall(action_options)
+        if current.installed
+          uninstall!
           updated!
         end
       end
@@ -71,6 +80,18 @@ module Itamae
         end
         if attributes.source
           cmd << '--source' << attributes.source
+        end
+        cmd << attributes.package_name
+
+        run_command(cmd)
+      end
+
+      def uninstall!
+        cmd = [*Array(attributes.gem_binary), 'uninstall', '--ignore-dependencies', '--executables', *Array(attributes.options)]
+        if attributes.version
+          cmd << '-v' << attributes.version
+        else
+          cmd << '--all'
         end
         cmd << attributes.package_name
 

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -176,6 +176,14 @@ describe command('gem list') do
   its(:stdout) { should include('tzinfo (1.2.2, 1.1.0)') }
 end
 
+describe command('gem list') do
+  its(:stdout) { should include('rake (11.1.0)') }
+end
+
+describe command('gem list') do
+  its(:stdout) { should_not include('test-unit') }
+end
+
 describe command('ri Bundler') do
   its(:stderr) { should eq("Nothing known about Bundler\n") }
 end

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -69,6 +69,31 @@ gem_package 'bundler' do
   options ['--no-ri', '--no-rdoc']
 end
 
+gem_package 'rake' do
+  version '11.1.0'
+end
+
+gem_package 'rake' do
+  version '11.2.2'
+end
+
+gem_package 'rake' do
+  action :uninstall
+  version '11.2.2'
+end
+
+gem_package 'test-unit' do
+  version '3.2.0'
+end
+
+gem_package 'test-unit' do
+  version '3.1.9'
+end
+
+gem_package 'test-unit' do
+  action :uninstall
+end
+
 ######
 
 execute "echo -n > /tmp/notifies"


### PR DESCRIPTION
Support feature of `gem uninstall`

# Example
```ruby
# uninstall all versions of gem
gem_package "bundler" do
  action :uninstall
end

# uninstall a specific version of gem
gem_package "bundler" do
  action :uninstall
  version "1.12.5"
end
```