### PR TITLE
Add recursive chmod/chown to remote_directory resource.

### DIFF
--- a/lib/itamae/resource/remote_directory.rb
+++ b/lib/itamae/resource/remote_directory.rb
@@ -9,6 +9,8 @@ module Itamae
       define_attribute :mode, type: String
       define_attribute :owner, type: String
       define_attribute :group, type: String
+      define_attribute :recursive_mode, type: [String, Symbol], default: :true
+      define_attribute :recursive_owner, type: [String, Symbol], default: :true
 
       def pre_action
         directory = ::File.expand_path(attributes.source, ::File.dirname(@recipe.path))
@@ -56,10 +58,18 @@ module Itamae
 
       def action_create(options)
         if attributes.mode
-          run_specinfra(:change_file_mode, @temppath, attributes.mode)
+          if attributes.recursive_mode == :true
+            run_specinfra(:change_file_mode, @temppath, attributes.mode, :recursive => true)
+          else
+            run_specinfra(:change_file_mode, @temppath, attributes.mode)
+          end
         end
         if attributes.owner || attributes.group
-          run_specinfra(:change_file_owner, @temppath, attributes.owner, attributes.group)
+          if attributes.recursive_owner == :true
+            run_specinfra(:change_file_owner, @temppath, attributes.owner, attributes.group, :recursive => true)
+          else
+            run_specinfra(:change_file_owner, @temppath, attributes.owner, attributes.group)
+          end
         end
 
         if run_specinfra(:check_file_is_file, attributes.path)


### PR DESCRIPTION
remote_directory resource with mode/owner/group attributes just only
work at root directory("path" attribute).

This patch add recursively option.  And set default(it is good or bad?).

Test case
---------

    remote_directory '/var/www/html/webapps' do
      owner 'apache'
      group 'apache'
      mode  'g+w'
      source webapps
    end