### PR TITLE
Add depth attribute to git resource

### DIFF
--- a/lib/itamae/resource/git.rb
+++ b/lib/itamae/resource/git.rb
@@ -10,6 +10,7 @@ module Itamae
       define_attribute :repository, type: String, required: true
       define_attribute :revision, type: String
       define_attribute :recursive, type: [TrueClass, FalseClass], default: false
+      define_attribute :depth, type: Integer
 
       def pre_action
         case @current_action
@@ -30,6 +31,7 @@ module Itamae
         if check_empty_dir
           cmd = ['git', 'clone']
           cmd << '--recursive' if attributes.recursive
+          cmd += ['--depth', attributes.depth.to_s] if attributes.depth
           cmd << attributes.repository << attributes.destination
           run_command(cmd)
           new_repository = true

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -149,6 +149,10 @@ describe command('cd /tmp/git_repo_submodule/empty_repo && cat README.md') do
   its(:stdout) { should match(/Empty Repo/) }
 end
 
+describe command('cd /tmp/git_repo_depth_1 && git rev-list --count HEAD') do
+  its(:stdout) { should eq "1\n" }
+end
+
 describe file('/tmp/created_by_itamae_user') do
   it { should be_file }
   it { should be_owned_by 'itamae' }

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -284,6 +284,11 @@ git "/tmp/git_repo_submodule" do
   recursive true
 end
 
+git "/tmp/git_repo_depth_1" do
+  repository "https://github.com/ryotarai/infrataster.git"
+  depth 1
+end
+
 #####
 
 execute "echo -n \"$HOME\n$(pwd)\" > /tmp/created_by_itamae_user" do


### PR DESCRIPTION
It would be nice to have depth option supported when you clone a git repository with long history.

This patch adds depth attribute to git resource that uses depth option when cloning like the example below;

```
git "/tmp/git_repo_depth_1" do
  repository "https://github.com/ryotarai/infrataster.git"
  depth 1
end

# => git clone --depth 1 https://github.com/ryotarai/infrataster.git /tmp/git_repo_depth_1
```