### PR TITLE
Do not touch destination @tempfile before send_file

### DIFF
--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -179,8 +179,6 @@ module Itamae
             backend.send_file(src, @temppath)
             @temppath = ::File.join(@temppath, ::File.basename(src))
           else
-            run_command(["touch", @temppath])
-            run_specinfra(:change_file_mode, @temppath, '0600')
             backend.send_file(src, @temppath)
           end
 


### PR DESCRIPTION
This will fix #220 and #214 .

Specifying `user` attribute on `file` resource and executing `itamae local` will create
`@tempfile` owned by user that specified by `user` attribute.

In that case, `FileUtils.cp` invoked by `backend.send_file(src, @temppath)` causes an error `Errno::EACCES`.
