### PR TITLE
Docker backend: Allow add repository name and tag to Image

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -269,6 +269,11 @@ module Itamae
     class Docker < Base
       def finalize
         image = @backend.commit_container
+
+        if @options.key?(:repository) && @options.key?(:tag)
+          image.tag(repo: @options[:repository], tag: @options[:tag], force: true)
+        end
+
         Itamae.logger.info "Image created: #{image.id}"
       end
 

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -65,6 +65,8 @@ module Itamae
     option :image, type: :string, desc: "This option or 'container' option is required."
     option :container, type: :string, desc: "This option or 'image' option is required."
     option :tls_verify_peer, type: :boolean, default: true
+    option :repository, type: :string, desc: "Docker image repository"
+    option :tag, type: :string, desc: "Docker image tag"
     def docker(*recipe_files)
       if recipe_files.empty?
         raise "Please specify recipe files."

--- a/spec/unit/lib/itamae/backend_spec.rb
+++ b/spec/unit/lib/itamae/backend_spec.rb
@@ -111,5 +111,36 @@ EOF
         end
       end
     end
+
+    describe Docker do
+      subject { described_class.new options }
+      let(:options) do
+        { image: "ubuntu:16.04", shell: "/bin/sh" }
+      end
+      let(:image) { double(tag: nil, id: 1) }
+      let(:backend) { double(commit_container: image) }
+
+      before do
+        allow(Specinfra::Backend::Docker).to receive(:new).with(docker_image: "ubuntu:16.04", shell: "/bin/sh", docker_container: nil).and_return(backend)
+      end
+
+      describe "#finalize" do
+        after { subject.finalize }
+
+        it { expect(backend).to receive(:commit_container).and_return(image) }
+
+        context "with repository and tag option" do
+          let(:options) do
+            { image: "ubuntu:16.04", shell: "/bin/sh", repository: "repository", tag: "tag" }
+          end
+
+          it { expect(image).to receive(:tag).with(repo: "repository", tag: "tag", force: true).and_return(nil) }
+        end
+
+        context "without repository and tag option" do
+          it { expect(image).to_not receive(:tag) }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Hey,
It would be nice to tag created image,
- Added cli options for docker (repository, tag)
