### PR TITLE
Dir.exists? is deprecated, use Dir.exist?

### DIFF
--- a/lib/itamae/recipe.rb
+++ b/lib/itamae/recipe.rb
@@ -121,7 +121,7 @@ module Itamae
 
       def include_recipe(target)
         expanded_path = ::File.expand_path(target, File.dirname(@recipe.path))
-        expanded_path = ::File.join(expanded_path, 'default.rb') if ::Dir.exists?(expanded_path)
+        expanded_path = ::File.join(expanded_path, 'default.rb') if ::Dir.exist?(expanded_path)
         expanded_path.concat('.rb') unless expanded_path.end_with?('.rb')
         candidate_paths = [expanded_path, Recipe.find_recipe_in_gem(target)].compact
         path = candidate_paths.find {|path| File.exist?(path) }


### PR DESCRIPTION
I just noticed deprecated method `Dir.exists?` is used.