### PR TITLE
Add support password authentication for ssh

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -234,6 +234,7 @@ module Itamae
         ssh_config_files = @options[:ssh_config] ? [@options[:ssh_config]] : Net::SSH::Config.default_files
         opts.merge!(Net::SSH::Config.for(@options[:host], ssh_config_files))
         opts[:user] = @options[:user] || opts[:user] || Etc.getlogin
+        opts[:password] = @options[:password] if @options[:password]
         opts[:keys] = [@options[:key]] if @options[:key]
         opts[:port] = @options[:port] if @options[:port]
 


### PR DESCRIPTION
Added support password authentication for ssh.

config.yml:

``` yaml
password: P@ssw0rd
```

and do as below.

``` shell
$ itamae ssh -h <host> -u <user> -c config.yml recipe.rb
```

You can run `itamae ssh` by password authentication.
