### PR TITLE
Support force link a direcotory

### DIFF
--- a/itamae.gemspec
+++ b/itamae.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "thor"
-  spec.add_runtime_dependency "specinfra", [">= 2.37.0", "< 3.0.0"]
+  spec.add_runtime_dependency "specinfra", [">= 2.64.0", "< 3.0.0"]
   spec.add_runtime_dependency "hashie"
   spec.add_runtime_dependency "ansi"
   spec.add_runtime_dependency "schash", "~> 0.1.0"

--- a/lib/itamae/resource/link.rb
+++ b/lib/itamae/resource/link.rb
@@ -25,7 +25,8 @@ module Itamae
 
       def action_create(options)
         unless run_specinfra(:check_file_is_linked_to, attributes.link, attributes.to)
-          run_specinfra(:link_file_to, attributes.link, attributes.to, force: attributes.force)
+          run_specinfra(:link_file_to, attributes.link, attributes.to,
+            force: attributes.force, no_dereference: attributes.force)
         end
       end
     end

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -148,6 +148,10 @@ describe file('/tmp-link-force') do
   it { should be_linked_to '/tmp' }
 end
 
+describe file('/tmp-link-force/tmp-link-force') do
+  it { should_not exist }
+end
+
 describe command('cd /tmp/git_repo && git rev-parse HEAD') do
   its(:stdout) { should match(/3116e170b89dc0f7315b69c1c1e1fd7fab23ac0d/) }
 end

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -148,7 +148,11 @@ describe file('/tmp-link-force') do
   it { should be_linked_to '/tmp' }
 end
 
-describe file('/tmp-link-force/tmp-link-force') do
+describe file('/tmp/link-force-no-dereference') do
+  it { should be_linked_to 'link-force-no-dereference2' }
+end
+
+describe file('/tmp/link-force-no-dereference/link-force-no-dereference2') do
   it { should_not exist }
 end
 

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -264,11 +264,25 @@ link "/tmp-link" do
 end
 
 execute "touch /tmp-link-force"
-2.times do
-  link "/tmp-link-force" do
-    to "/tmp"
-    force true
-  end
+link "/tmp-link-force" do
+  to "/tmp"
+  force true
+end
+
+######
+
+execute "mkdir /tmp/link-force-no-dereference1"
+link "link-force-no-dereference" do
+  cwd "/tmp"
+  to "link-force-no-dereference1"
+  force true
+end
+
+execute "mkdir /tmp/link-force-no-dereference2"
+link "link-force-no-dereference" do
+  cwd "/tmp"
+  to "link-force-no-dereference2"
+  force true
 end
 
 #####

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -264,9 +264,11 @@ link "/tmp-link" do
 end
 
 execute "touch /tmp-link-force"
-link "/tmp-link-force" do
-  to "/tmp"
-  force true
+2.times do
+  link "/tmp-link-force" do
+    to "/tmp"
+    force true
+  end
 end
 
 #####


### PR DESCRIPTION
Hi maintainers

On [v2.64.0](https://github.com/mizzy/specinfra/releases/tag/v2.64.0), specinfra supports link no-dereference option.
This p-r is to apply this change.

## Discussion Point

I let the `no_dereference` option melted into `force` option. It's because ...
  - In the context of provisioning, the behaviour should not be changed by whether the target is a file symlink, a directory symlink, a file or a directory.
  - [`chef` always deletes the old file symlink, directory symlink, file or directory before linking new.](https://github.com/chef/chef/blob/719718f35169670bd79be8cd595bdf0fe4b0e221/lib/chef/provider/link.rb#L101-L118)

I want to discuss the above because the default behaviour may be changed.

## What I want to solve

For example, I manage versions of google-cloud-sdk by using symlink. In the below case, I need to change the `current` symlink destination to upgrade `google-cloud-sdk-100.0.0-linux-x86_64` to `google-cloud-sdk-132.0.0-linux-x86_64`. However, now itamae supports only `ln -f` option, so the new symlink is created under the `current` directory.

```
# ls -l /opt/google-cloud-sdk/
total 8
lrwxrwxrwx 1 root root   37 Oct 27 11:31 current -> google-cloud-sdk-100.0.0-linux-x86_64
drwxr-xr-x 7 root root 4096 Oct 27 11:31 google-cloud-sdk-100.0.0-linux-x86_64
drwxr-xr-x 7 root root 4096 Oct 24 15:27 google-cloud-sdk-132.0.0-linux-x86_64
# ls -l /opt/google-cloud-sdk/current/
total 108
drwxr-xr-x 3 root root  4096 Oct 27 11:31 bin
-rw-r--r-- 1 root root  2338 Oct 27 11:31 completion.bash.inc
-rw-r--r-- 1 root root  1923 Oct 27 11:31 completion.zsh.inc
lrwxrwxrwx 1 root root    24 Oct 27 11:33 current -> google-cloud-sdk-132.0.0-linux-x86_64
drwxr-xr-x 3 root root  4096 Oct 27 11:31 help
-rwxr-xr-x 1 root root  1581 Oct 27 11:31 install.bat
-rwxr-xr-x 1 root root  3374 Oct 27 11:31 install.sh
drwxr-xr-x 5 root root  4096 Oct 27 11:31 lib
-rw-r--r-- 1 root root   980 Oct 27 11:31 LICENSE
-rw-r--r-- 1 root root   308 Oct 27 11:31 path.bash.inc
-rw-r--r-- 1 root root    31 Oct 27 11:31 path.zsh.inc
drwxr-xr-x 5 root root  4096 Oct 27 11:31 platform
-rw-r--r-- 1 root root    39 Oct 27 11:31 properties
-rw-r--r-- 1 root root   684 Oct 27 11:31 README
-rw-r--r-- 1 root root 55813 Oct 27 11:31 RELEASE_NOTES
```

```
link "current" do
  to "google-cloud-sdk-132.0.0-linux-x86_64"
  cwd "/opt/google-cloud-sdk/"
  force true
end
```

---

That's it. Could you check this?