### PR TITLE
Support for adding docker image tag

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -269,6 +269,7 @@ module Itamae
     class Docker < Base
       def finalize
         image = @backend.commit_container
+        image.tag(repo: @options[:repo], tag: @options[:tag]) if @options[:repo]
         Itamae.logger.info "Image created: #{image.id}"
       end
 

--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -269,14 +269,8 @@ module Itamae
     class Docker < Base
       def finalize
         image = @backend.commit_container
-        if @options[:tag]
-          opt = @options[:tag].split(':')
-          if opt.size > 2
-            # private docker registry
-            image.tag(repo: opt[0..1].join(':'), tag: opt[2])
-          else
-            image.tag(repo: opt[0], tag: opt[1])
-          end
+        /\A(?<repo>.+?)(?:|:(?<tag>[^:]+))\z/.match(@options[:tag]) do |m|
+          image.tag(repo: m[:repo], tag: m[:tag])
         end
         Itamae.logger.info "Image created: #{image.id}"
       end

--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -269,7 +269,10 @@ module Itamae
     class Docker < Base
       def finalize
         image = @backend.commit_container
-        image.tag(repo: @options[:repository], tag: @options[:tag]) if @options[:repository]
+        if @options[:tag]
+          repo, tag = @options[:tag].split(':')
+          image.tag(repo: repo, tag: tag)
+        end
         Itamae.logger.info "Image created: #{image.id}"
       end
 

--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -270,7 +270,7 @@ module Itamae
       def finalize
         image = @backend.commit_container
         if @options[:tag]
-          repo, tag = @options[:tag].split(':')
+          repo, _, tag = @options[:tag].rpartition(':')
           image.tag(repo: repo, tag: tag)
         end
         Itamae.logger.info "Image created: #{image.id}"

--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -269,10 +269,7 @@ module Itamae
     class Docker < Base
       def finalize
         image = @backend.commit_container
-        if @options[:tag]
-          repo, _, tag = @options[:tag].rpartition(':')
-          image.tag(repo: repo, tag: tag)
-        end
+        image.tag(repo: @options[:repository], tag: @options[:tag]) if @options[:repository]
         Itamae.logger.info "Image created: #{image.id}"
       end
 

--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -269,7 +269,15 @@ module Itamae
     class Docker < Base
       def finalize
         image = @backend.commit_container
-        image.tag(repo: @options[:repository], tag: @options[:tag]) if @options[:repository]
+        if @options[:tag]
+          opt = @options[:tag].split(':')
+          if opt.size > 2
+            # private docker registry
+            image.tag(repo: opt[0..1].join(':'), tag: opt[2])
+          else
+            image.tag(repo: opt[0], tag: opt[1])
+          end
+        end
         Itamae.logger.info "Image created: #{image.id}"
       end
 

--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -269,7 +269,7 @@ module Itamae
     class Docker < Base
       def finalize
         image = @backend.commit_container
-        image.tag(repo: @options[:repo], tag: @options[:tag]) if @options[:repo]
+        image.tag(repo: @options[:repository], tag: @options[:tag]) if @options[:repository]
         Itamae.logger.info "Image created: #{image.id}"
       end
 

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -65,6 +65,7 @@ module Itamae
     option :image, type: :string, desc: "This option or 'container' option is required."
     option :container, type: :string, desc: "This option or 'image' option is required."
     option :tls_verify_peer, type: :boolean, default: true
+    option :repository, type: :string
     option :tag, type: :string
     def docker(*recipe_files)
       if recipe_files.empty?

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -65,6 +65,8 @@ module Itamae
     option :image, type: :string, desc: "This option or 'container' option is required."
     option :container, type: :string, desc: "This option or 'image' option is required."
     option :tls_verify_peer, type: :boolean, default: true
+    option :repository, type: :string
+    option :tag, type: :string
     def docker(*recipe_files)
       if recipe_files.empty?
         raise "Please specify recipe files."

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -65,7 +65,6 @@ module Itamae
     option :image, type: :string, desc: "This option or 'container' option is required."
     option :container, type: :string, desc: "This option or 'image' option is required."
     option :tls_verify_peer, type: :boolean, default: true
-    option :repository, type: :string
     option :tag, type: :string
     def docker(*recipe_files)
       if recipe_files.empty?


### PR DESCRIPTION
I added 2 options(repository, tag) to `itamae docker` command.

```
itamae docker --image=alpine --repository=foo:5000/bar --tag=v1 recipe.rb
# -> created image: repository=foo:5000/bar tag=v1

itamae docker --image=alpine --repository=foo --tag=v2 recipe.rb
# -> created image: repository=foo tag=v2

itamae docker --image=alpine --repository=foo recipe.rb
# -> created image: repository=foo tag=latest
```