### PR TITLE
added ssh option 'keys_only: true' when not using password login issue #232

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -257,6 +257,8 @@ module Itamae
           password = STDIN.noecho(&:gets).strip
           print "\n"
           opts.merge!(password: password)
+        else\
+          opts.merge!(keys_only: true)
         end
 
         opts


### PR DESCRIPTION
From https://net-ssh.github.io/ssh/v2/api/classes/Net/SSH.html

:keys_only => set to true to use only private keys from keys and key_data parameters, even if ssh-agent offers more identities. This option is intended for situations where ssh-agent offers many different identites.