### PR TITLE
Enable only when options are found

### DIFF
--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -5,10 +5,6 @@ module Itamae
   class CLI < Thor
     GENERATE_TARGETS = %w[cookbook role].freeze
 
-    class_option :log_level, type: :string, aliases: ['-l'], default: 'info'
-    class_option :color, type: :boolean, default: true
-    class_option :config, type: :string, aliases: ['-c']
-
     def initialize(*)
       super
 
@@ -26,6 +22,9 @@ module Itamae
       option :ohai, type: :boolean, default: false, desc: "This option is DEPRECATED and will be unavailable."
       option :profile, type: :string, desc: "[EXPERIMENTAL] Save profiling data", banner: "PATH"
       option :detailed_exitcode, type: :boolean, default: false, desc: "exit code 0 - The run succeeded with no changes or failures, exit code 1 - The run failed, exit code 2 - The run succeeded, and some resources were changed"
+      option :log_level, type: :string, aliases: ['-l'], default: 'info'
+      option :color, type: :boolean, default: true
+      option :config, type: :string, aliases: ['-c']
     end
 
     desc "local RECIPE [RECIPE...]", "Run Itamae locally"

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -12,8 +12,8 @@ module Itamae
     def initialize(*)
       super
 
-      Itamae.logger.level = ::Logger.const_get(options[:log_level].upcase)
-      Itamae.logger.formatter.colored = options[:color]
+      Itamae.logger.level = ::Logger.const_get(options[:log_level].upcase) if options[:log_level]
+      Itamae.logger.formatter.colored = options[:color] if options[:color]
     end
 
     def self.define_exec_options


### PR DESCRIPTION
## Issue

Can't use help command #234

## Description

The `thor` implements `disable_class_options` at this commit. https://github.com/erikhuda/thor/commit/eda908053e137ac640a151e61895e433adfb4ad4

So `--log_level` and `--color` options are disappeared from `help` sub-command.

I tried to bypass logger configuration when class options not found.

Is this Pull Request correct ??