### PR TITLE
Support ERB in node attributes yaml files

### DIFF
--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -115,7 +115,7 @@ module Itamae
       if @options[:node_yaml]
         path = File.expand_path(@options[:node_yaml])
         Itamae.logger.info "Loading node data from #{path}..."
-        hash.merge!(YAML.load(open(path)) || {})
+        hash.merge!(YAML.load(ERB.new(open(path).read).result) || {})
       end
 
       Node.new(hash, @backend)


### PR DESCRIPTION
Hi.

I'm using some node attributes files divided by server roles, but in some case, want to share attributes among the files.

example
```yaml
# role1.yml
---
users: # I want to share
  - name: hoge
  - name: fuga
ruby:
  version: 2.4

# role2.yml
---
users: # I want to share
  - name: hoge
  - name: fuga
ruby:
  version: 2.3
```

So I want to write erb in node yaml files, and include other files by ruby.

example
```yaml
# role1.yml
---
<%= open(File.expand_path("../users.yml", __FILE__)).read %>

ruby:
  version: 2.4

# role2.yml
---
<%= open(File.expand_path("../users.yml", __FILE__)).read %>

ruby:
  version: 2.3

# users.yml
---
users:
  - name: hoge
  - name: fuga
```

What do you think about my idea?