### PR TITLE
add support of FreeBSD Jail

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -212,6 +212,17 @@ module Itamae
       end
     end
 
+    class Jexec < Base
+      private
+      def create_specinfra_backend
+        Specinfra::Backend::Jexec.new(
+          shell: @options[:shell],
+          login_shell: @options[:login_shell],
+          jail_name: @options[:jail_name],
+        )
+      end
+    end
+
     class Ssh < Base
       private
       def create_specinfra_backend

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -73,6 +73,17 @@ module Itamae
       run(recipe_files, :docker, options)
     end
 
+    desc "jail RECIPE [RECIPE...]", "Run Itamae in jail"
+    define_exec_options
+    option :jail_name, type: :string, desc: "Jail Hostname"
+    def jail(*recipe_files)
+      if recipe_files.empty?
+        raise "Please specify recipe files."
+      end
+
+      run(recipe_files, :jexec, options)
+    end
+
     desc "version", "Print version"
     def version
       puts "Itamae v#{Itamae::VERSION}"

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -83,11 +83,11 @@ gem_package 'rake' do
 end
 
 gem_package 'test-unit' do
-  version '3.1.9'
+  version '3.2.0'
 end
 
 gem_package 'test-unit' do
-  version '3.0.9'
+  version '3.1.9'
 end
 
 gem_package 'test-unit' do

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -83,11 +83,11 @@ gem_package 'rake' do
 end
 
 gem_package 'test-unit' do
-  version '3.2.0'
+  version '3.1.9'
 end
 
 gem_package 'test-unit' do
-  version '3.1.9'
+  version '3.0.9'
 end
 
 gem_package 'test-unit' do

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 node.reverse_merge!({
   message: "Hello, Itamae"
 })
@@ -84,7 +83,7 @@ gem_package 'rake' do
 end
 
 gem_package 'test-unit' do
-  version '3.1.8'
+  version '3.1.9'
 end
 
 gem_package 'test-unit' do

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 node.reverse_merge!({
   message: "Hello, Itamae"
 })
@@ -83,7 +84,7 @@ gem_package 'rake' do
 end
 
 gem_package 'test-unit' do
-  version '3.1.9'
+  version '3.1.8'
 end
 
 gem_package 'test-unit' do


### PR DESCRIPTION
I wrote a patch that makes Itamae to support FreeBSD jail (*1).
I tested all Itamae resources work with Specinfra-2.70.1.

My fix is quite simple.
 
 1. added jexec backend which executes specinfra commands in jail.
 2. added Itamae jail subcommand.

Here is a example to use Itamae jail subcommand.

```
$ su
# itamae jail --jail_name <jail_name> <recipe> ...
```

Itamae jail subcommand requires root privilege,
because FreeBSD's jexec command requires root privilege.

Will you see my fixes and merge this Pull Request?

*1: FreeBSD jail information
https://www.freebsd.org/doc/handbook/jails.html
https://ja.wikipedia.org/wiki/FreeBSD_jail
