### PR TITLE
Fail `--ohai` option when using ohai v13.0.1 or higher #240

### DIFF
--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -103,7 +103,7 @@ module Itamae
         end
 
         Itamae.logger.info "Loading node data via ohai..."
-        hash.merge!(JSON.parse(@backend.run_command("ohai").stdout))
+        hash.merge!(JSON.parse(@backend.run_command("ohai 2>/dev/null").stdout))
       end
 
       if @options[:node_json]


### PR DESCRIPTION
Regarding to #240, let me submit this PR.  Here the summary of the issue:

## Phenomenon

itamae ssh --ohai fails when ohai >= v8.24.0 is installed at the target host.

## Reason

1. Net::SSH (or openssh) with pty merges stdout and stderr as discussed at https://github.com/net-ssh/net-ssh/issues/51
1. ohai generates INFO message to stderr.  Since v8.24.0, it checks whether if /etc/chef/ohai/plugins directory exists and report to stderr.  This message is merged into stdout on ssh because of 1. above so that ohai output is corrupted.

## Workaround

Workaround might be:

1. fix Net::SSH, or
1. mkdir /etc/chef/ohai/plugins at ohai executed host, or
1. isolate stderr from stdout at itamae side.

This PR is 3rd one above.