### PR TITLE
Print '(dry-run)' first in dry-run mode

### DIFF
--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -6,7 +6,7 @@ module Itamae
   class Runner
     class << self
       def run(recipe_files, backend_type, options)
-        Itamae.logger.info "Starting Itamae..."
+        Itamae.logger.info "Starting Itamae... #{options[:dry_run] ? '(dry-run)' : ''}"
 
         backend = Backend.create(backend_type, options)
         runner = self.new(backend, options)


### PR DESCRIPTION
In dry-run mode, add "(dry-run)" in "Starting Itamae" message.

```
$ bundle exec itamae ssh --user foo --host example.com role.rb --dry-run
 INFO : Starting Itamae... (dry-run)
 ....
```

## motivation
I use codenize-tools often. It's print "dry-run" as a first in dry-run mode.

e.g as roadworker,

```
$ bundle exec roadwork --apply --dry-run
Apply `Routefile` to Route53 (dry-run)
No change
```

https://github.com/codenize-tools/roadworker

The behavior is human-friendly I think. So I want to bring its behavior in itamae.

## concern
`Itamae::Runner.run` is the class method. In instanced `Itamae::Runner` has `@option` attribute and `dry_run?` method.
I want to use it but it's not instanced in the location of the first log message. So reading `options` variable as direct.

```ruby
Itamae.logger.info "Starting Itamae... #{options[:dry_run] ? '(dry-run)' : ''}"
```