### PR TITLE
Fixed: edit action of file resource doesn't work with docker backend

### DIFF
--- a/lib/itamae/ext/specinfra.rb
+++ b/lib/itamae/ext/specinfra.rb
@@ -18,6 +18,16 @@ module Specinfra
       end
     end
 
+    class Docker < Exec
+      def receive_file(from, to = nil)
+        if to
+          send_file(from, to)
+        else
+          run_command("cat #{from}").stdout
+        end
+      end
+    end
+
     class Ssh < Exec
       def receive_file(from, to = nil)
         scp_download!(from, to)


### PR DESCRIPTION
# Backtrace
```
$ bundle exec bin/itamae docker spec/integration/recipes/default.rb

(snip)

bundler: failed to load command: itamae (/Users/sue445/workspace/github.com/itamae-kitchen/itamae/vendor/bundle/ruby/2.5.0/bin/itamae)
Errno::ENOENT: No such file or directory @ rb_sysopen - /tmp/file_edit_sample
  /Users/sue445/workspace/github.com/itamae-kitchen/itamae/lib/itamae/ext/specinfra.rb:16:in `read'
  /Users/sue445/workspace/github.com/itamae-kitchen/itamae/lib/itamae/ext/specinfra.rb:16:in `receive_file'
  /Users/sue445/workspace/github.com/itamae-kitchen/itamae/lib/itamae/backend.rb:98:in `receive_file'
  /Users/sue445/workspace/github.com/itamae-kitchen/itamae/lib/itamae/resource/file.rb:26:in `pre_action'
  /Users/sue445/workspace/github.com/itamae-kitchen/itamae/lib/itamae/resource/base.rb:180:in `block (2 levels) in run_action'
  /Users/sue445/workspace/github.com/itamae-kitchen/itamae/lib/itamae/logger.rb:19:in `with_indent_if'
  /Users/sue445/workspace/github.com/itamae-kitchen/itamae/lib/itamae/resource/base.rb:178:in `block in run_action'
  /Users/sue445/workspace/github.com/itamae-kitchen/itamae/lib/itamae/handler_proxy.rb:29:in `_event_with_block'
```