### PR TITLE
Fixed rspec warning

### DIFF
--- a/spec/unit/lib/itamae/handler_proxy_spec.rb
+++ b/spec/unit/lib/itamae/handler_proxy_spec.rb
@@ -20,8 +20,8 @@ module Itamae
             expect(handler).to receive(:event).with(:name_started, :arg)
             expect(handler).to receive(:event).with(:name_failed, :arg)
             expect {
-              subject.event(:name, :arg) { raise }
-            }.to raise_error
+              subject.event(:name, :arg) { raise "name is failed" }
+            }.to raise_error "name is failed"
           end
         end
       end


### PR DESCRIPTION
c.f. https://travis-ci.org/itamae-kitchen/itamae/jobs/444002797

```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives,
since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`,
potentially allowing the expectation to pass without even executing the method you are intending to call.
Actual error raised was RuntimeError. Instead consider providing a specific error class or message.
This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`.
Called from /home/travis/build/itamae-kitchen/itamae/spec/unit/lib/itamae/handler_proxy_spec.rb:22:in `block (5 levels) in <module:Itamae>'.
```

@unasuke 