### PR TITLE
Fixed. test is failing after run test 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,12 +22,14 @@ namespace :spec do
       task target => ["docker:#{target}", "provision:#{target}", "serverspec:#{target}"]
 
       namespace :docker do
+        desc "Run docker for #{target}"
         task target do
           sh "docker run --privileged -d --name itamae #{target} /sbin/init"
         end
       end
 
       namespace :provision do
+        desc "Run itamae to #{target}"
         task target do
           suites = [
             [

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -271,14 +271,14 @@ end
 
 ######
 
-execute "mkdir /tmp/link-force-no-dereference1"
+execute "mkdir -p /tmp/link-force-no-dereference1"
 link "link-force-no-dereference" do
   cwd "/tmp"
   to "link-force-no-dereference1"
   force true
 end
 
-execute "mkdir /tmp/link-force-no-dereference2"
+execute "mkdir -p /tmp/link-force-no-dereference2"
 link "link-force-no-dereference" do
   cwd "/tmp"
   to "link-force-no-dereference2"


### PR DESCRIPTION
# Overview
## 1st test

```bash
$ be rake spec:integration:provision:ubuntu:trusty
#=> success
```

## 2nd test (run same task)

```bash
$ be rake spec:integration:provision:ubuntu:trusty

(snip)

INFO :   execute[mkdir /tmp/link-force-no-dereference1] executed will change from 'false' to 'true'
ERROR :     stderr | mkdir: cannot create directory '/tmp/link-force-no-dereference1': File exists
ERROR :     Command `mkdir /tmp/link-force-no-dereference1` failed. (exit status: 1)
ERROR :   execute[mkdir /tmp/link-force-no-dereference1] Failed.
rake aborted!
```

@unasuke 