### PR TITLE
Support `only_if` and `not_if` inside a `define`

### DIFF
--- a/lib/itamae/recipe.rb
+++ b/lib/itamae/recipe.rb
@@ -161,6 +161,18 @@ module Itamae
         context.instance_eval(&@definition.class.definition_block)
       end
 
+      def run
+        if @definition.do_not_run_because_of_only_if?
+          Itamae.logger.debug "#{@definition.resource_type}[#{@definition.resource_name}] Execution skipped because of only_if attribute"
+          return
+        elsif @definition.do_not_run_because_of_not_if?
+          Itamae.logger.debug "#{@definition.resource_type}[#{@definition.resource_name}] Execution skipped because of not_if attribute"
+          return
+        end
+
+        super
+      end
+
       private
 
       def show_banner

--- a/lib/itamae/resource/base.rb
+++ b/lib/itamae/resource/base.rb
@@ -160,6 +160,16 @@ module Itamae
         self.class.name.split("::").last.scan(/[A-Z][^A-Z]+/).map(&:downcase).join('_')
       end
 
+      def do_not_run_because_of_only_if?
+        @only_if_command &&
+          run_command(@only_if_command, error: false).exit_status != 0
+      end
+
+      def do_not_run_because_of_not_if?
+        @not_if_command &&
+          run_command(@not_if_command, error: false).exit_status == 0
+      end
+
       private
 
       alias_method :current, :current_attributes
@@ -268,16 +278,6 @@ module Itamae
             end
           end
         end
-      end
-
-      def do_not_run_because_of_only_if?
-        @only_if_command &&
-          run_command(@only_if_command, error: false).exit_status != 0
-      end
-
-      def do_not_run_because_of_not_if?
-        @not_if_command &&
-          run_command(@not_if_command, error: false).exit_status == 0
       end
 
       def backend

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -227,6 +227,42 @@ describe file('/tmp/remote_file_in_definition') do
   its(:content) { should eq("definition_example\n") }
 end
 
+describe file('/tmp/created_by_definition_2_created') do
+  it { should be_file }
+  its(:content) { should eq("name:created,key:value2,message:Hello, Itamae\n") }
+end
+
+describe file('/tmp/remote_file_in_definition_2_created') do
+  it { should be_file }
+  its(:content) { should eq("definition_example_2\n") }
+end
+
+describe file('/tmp/created_by_definition_2_not_created') do
+  it { should_not exist }
+end
+
+describe file('/tmp/remote_file_in_definition_2_not_created') do
+  it { should_not exist }
+end
+
+describe file('/tmp/created_by_definition_3_created') do
+  it { should be_file }
+  its(:content) { should eq("name:created,key:value3,message:Hello, Itamae\n") }
+end
+
+describe file('/tmp/remote_file_in_definition_3_created') do
+  it { should be_file }
+  its(:content) { should eq("definition_example_3\n") }
+end
+
+describe file('/tmp/created_by_definition_3_not_created') do
+  it { should_not exist }
+end
+
+describe file('/tmp/remote_file_in_definition_3_not_created') do
+  it { should_not exist }
+end
+
 describe file('/tmp/multi_delayed_notifies') do
   it { should be_file }
   its(:content) { should eq("1\n2\n3\n4\n") }

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -342,6 +342,28 @@ definition_example "name" do
   key 'value'
 end
 
+execute "touch /tmp/trigger_for_definition_example_2"
+
+definition_example_2 "created" do
+  key     "value2"
+  only_if "test -f /tmp/trigger_for_definition_example_2"
+end
+
+definition_example_2 "not_created" do
+  key    "value2"
+  not_if "test -f /tmp/trigger_for_definition_example_2"
+end
+
+definition_example_3 "created" do
+  key    "value3"
+  not_if "test -f /tmp/this_file_is_not_exists"
+end
+
+definition_example_3 "not_created" do
+  key     "value3"
+  only_if "test -f /tmp/this_file_is_not_exists"
+end
+
 #####
 
 file "/tmp/never_exist4" do

--- a/spec/integration/recipes/define/default.rb
+++ b/spec/integration/recipes/define/default.rb
@@ -4,3 +4,18 @@ define :definition_example, key: 'default' do
   remote_file "/tmp/remote_file_in_definition"
 end
 
+define :definition_example_2, key: 'default' do
+  execute "echo 'name:#{params[:name]},key:#{params[:key]},message:#{node[:message]}' > /tmp/created_by_definition_2_#{params[:name]}"
+
+  remote_file "/tmp/remote_file_in_definition_2_#{params[:name]}" do
+    source "files/remote_file_in_definition_2"
+  end
+end
+
+define :definition_example_3, key: 'default' do
+  execute "echo 'name:#{params[:name]},key:#{params[:key]},message:#{node[:message]}' > /tmp/created_by_definition_3_#{params[:name]}"
+
+  remote_file "/tmp/remote_file_in_definition_3_#{params[:name]}" do
+    source "files/remote_file_in_definition_3"
+  end
+end

--- a/spec/integration/recipes/define/files/remote_file_in_definition_2
+++ b/spec/integration/recipes/define/files/remote_file_in_definition_2
@@ -1,0 +1,1 @@
+definition_example_2

--- a/spec/integration/recipes/define/files/remote_file_in_definition_3
+++ b/spec/integration/recipes/define/files/remote_file_in_definition_3
@@ -1,0 +1,1 @@
+definition_example_3

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -14,3 +14,10 @@ set :docker_container, ENV["DOCKER_CONTAINER"]
 
 # Set PATH
 # set :path, '/sbin:/usr/local/sbin:$PATH'
+
+RSpec.configure do |config|
+  unless ENV["CI"]
+    # focus is enabled only local (Run all specs at CI)
+    config.filter_run_when_matching :focus
+  end
+end


### PR DESCRIPTION
c.f. #262

# Example
```ruby
define :some_definition do
end

# this is executed
some_definition do
  only_if "exit 0"
end

# this is not executed
some_definition do
  only_if "exit 1"
end
```

Close #262 
Close #161
