### PR TITLE
Disable mash warnings (review catch up)

### DIFF
--- a/lib/itamae.rb
+++ b/lib/itamae.rb
@@ -13,6 +13,7 @@ require "itamae/notification"
 require "itamae/definition"
 require "itamae/ext"
 require "itamae/generators"
+require "itamae/mash"
 
 module Itamae
   # Your code goes here...

--- a/lib/itamae/mash.rb
+++ b/lib/itamae/mash.rb
@@ -1,0 +1,7 @@
+require 'hashie'
+
+module Itamae
+  class Mash < Hashie::Mash
+    disable_warnings
+  end
+end

--- a/lib/itamae/node.rb
+++ b/lib/itamae/node.rb
@@ -1,4 +1,5 @@
 require 'itamae'
+require 'itamae/mash'
 require 'hashie'
 require 'json'
 require 'schash'
@@ -10,7 +11,7 @@ module Itamae
     attr_reader :mash
 
     def initialize(hash, backend)
-      @mash = Hashie::Mash.new(hash)
+      @mash = Itamae::Mash.new(hash)
       @backend = backend
     end
 
@@ -43,7 +44,7 @@ module Itamae
     private
 
     def _reverse_merge(other_hash)
-      Hashie::Mash.new(other_hash).merge(@mash)
+      Itamae::Mash.new(other_hash).merge(@mash)
     end
 
     def method_missing(method, *args)
@@ -63,7 +64,7 @@ module Itamae
     def fetch_inventory_value(key)
       value = @backend.host_inventory[key]
       if value.is_a?(Hash)
-        value = Hashie::Mash.new(value)
+        value = Itamae::Mash.new(value)
       end
 
       value

--- a/lib/itamae/node.rb
+++ b/lib/itamae/node.rb
@@ -1,5 +1,4 @@
 require 'itamae'
-require 'itamae/mash'
 require 'hashie'
 require 'json'
 require 'schash'

--- a/lib/itamae/resource/base.rb
+++ b/lib/itamae/resource/base.rb
@@ -16,7 +16,7 @@ module Itamae
         def initialize(resource)
           @resource = resource
 
-          @attributes = Hashie::Mash.new
+          @attributes = Itamae::Mash.new
           @notifications = []
           @subscriptions = []
           @verify_commands = []
@@ -222,7 +222,7 @@ module Itamae
       end
 
       def clear_current_attributes
-        @current_attributes = Hashie::Mash.new
+        @current_attributes = Itamae::Mash.new
       end
 
       def pre_action


### PR DESCRIPTION
## original pull request description ( by @hnmx4 )
for https://github.com/itamae-kitchen/itamae/issues/243.
I use a Hashie developer’s solution that solves issue similar to issue#243 as  reference.

https://github.com/intridea/hashie/issues/394
> I just released Hashie v3.5.2 which has the disable_warnings feature for the Mash logger and sets the Hashie logger to the Rails logger when we detect that we're running in Rails. Hopefully, this helps!

https://github.com/intridea/hashie
> You can also disable the logging in subclasses of Mash:
>
> ```
> class Response < Hashie::Mash
>   disable_warnings
> end
> ```

------

I added commits for @sue445 's comment 

>  I prefer add require 'itamae/mash' to lib/itamae.rb than here.

https://github.com/itamae-kitchen/itamae/pull/244#discussion_r224300318