### PR TITLE
Make `send_file` aware of `user` option

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -98,7 +98,7 @@ module Itamae
         @backend.receive_file(src, dst)
       end
 
-      def send_file(src, dst)
+      def send_file(src, dst, user: nil)
         Itamae.logger.debug "Sending a file from '#{src}' to '#{dst}'..."
         unless ::File.exist?(src)
           raise SourceNotExistError, "The file '#{src}' doesn't exist."
@@ -106,7 +106,12 @@ module Itamae
         unless ::File.file?(src)
           raise SourceNotExistError, "'#{src}' is not a file."
         end
-        @backend.send_file(src, dst)
+
+        if self.instance_of?(Backend::Local)
+          run_command(get_command(:copy_file, src, dst), user: user)
+        else
+          @backend.send_file(src, dst)
+        end
       end
 
       def send_directory(src, dst)

--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -108,7 +108,10 @@ module Itamae
         end
 
         if self.instance_of?(Backend::Local)
-          run_command(get_command(:copy_file, src, dst), user: user)
+          read_command = build_command("cat #{src.shellescape}", {})
+          write_command = build_command("cat > #{dst.shellescape}", user: user)
+          command = [read_command, write_command].join(' | ')
+          run_command(command)
         else
           @backend.send_file(src, dst)
         end

--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -183,12 +183,12 @@ module Itamae
 
           if backend.is_a?(Itamae::Backend::Docker)
             run_command(["mkdir", @temppath])
-            backend.send_file(src, @temppath)
+            backend.send_file(src, @temppath, user: attributes.user)
             @temppath = ::File.join(@temppath, ::File.basename(src))
           else
             run_command(["touch", @temppath])
             run_specinfra(:change_file_mode, @temppath, '0600')
-            backend.send_file(src, @temppath)
+            backend.send_file(src, @temppath, user: attributes.user)
           end
 
           run_specinfra(:change_file_mode, @temppath, '0600')

--- a/spec/integration/local_spec.rb
+++ b/spec/integration/local_spec.rb
@@ -1,0 +1,6 @@
+describe file('/tmp/file_as_ordinary_user') do
+  it { should be_file }
+  it { should be_owned_by "itamae" }
+  it { should be_grouped_into "itamae" }
+end
+

--- a/spec/integration/ordinary_user_spec.rb
+++ b/spec/integration/ordinary_user_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+describe file('/tmp/remote_file') do
+  it { should be_file }
+  it { should be_owned_by "ordinary_san" }
+  it { should be_grouped_into "ordinary_san" }
+  its(:content) { should match(/Hello Itamae/) }
+end
+
+describe file('/tmp/remote_file_root') do
+  it { should be_file }
+  it { should be_owned_by "root" }
+  it { should be_grouped_into "root" }
+  its(:content) { should match(/Hello Itamae/) }
+end
+
+describe file('/tmp/remote_file_another_ordinary') do
+  it { should be_file }
+  it { should be_owned_by "itamae" }
+  it { should be_grouped_into "itamae" }
+  its(:content) { should match(/Hello Itamae/) }
+end
+
+describe file('/tmp/file') do
+  it { should be_file }
+  it { should be_owned_by "ordinary_san" }
+  it { should be_grouped_into "ordinary_san" }
+  its(:content) { should match(/Hello World/) }
+end
+
+describe file('/tmp/file_root') do
+  it { should be_file }
+  it { should be_owned_by "root" }
+  it { should be_grouped_into "root" }
+  its(:content) { should match(/Hello World/) }
+end
+
+describe file('/tmp/file_another_ordinary') do
+  it { should be_file }
+  it { should be_owned_by "itamae" }
+  it { should be_grouped_into "itamae" }
+  its(:content) { should match(/Hello World/) }
+end
+
+describe file('/tmp/template') do
+  it { should be_file }
+  it { should be_owned_by "ordinary_san" }
+  it { should be_grouped_into "ordinary_san" }
+  its(:content) { should match(/Hello/) }
+  its(:content) { should match(/Good bye/) }
+  its(:content) { should match(/^total memory: \d+kB$/) }
+  its(:content) { should match(/^uninitialized node key: $/) }
+end
+
+describe file('/tmp/template_root') do
+  it { should be_file }
+  it { should be_owned_by "root" }
+  it { should be_grouped_into "root" }
+  its(:content) { should match(/Hello/) }
+  its(:content) { should match(/Good bye/) }
+  its(:content) { should match(/^total memory: \d+kB$/) }
+  its(:content) { should match(/^uninitialized node key: $/) }
+end
+
+describe file('/tmp/template_another_ordinary') do
+  it { should be_file }
+  it { should be_owned_by "itamae" }
+  it { should be_grouped_into "itamae" }
+  its(:content) { should match(/Hello/) }
+  its(:content) { should match(/Good bye/) }
+  its(:content) { should match(/^total memory: \d+kB$/) }
+  its(:content) { should match(/^uninitialized node key: $/) }
+end
+
+describe file('/tmp/http_request.html') do
+  it { should be_file }
+  it { should be_owned_by "ordinary_san" }
+  it { should be_grouped_into "ordinary_san" }
+  its(:content) { should match(/"from":\s*"itamae"/) }
+end
+
+describe file('/tmp/http_request_root.html') do
+  it { should be_file }
+  it { should be_owned_by "root" }
+  it { should be_grouped_into "root" }
+  its(:content) { should match(/"from":\s*"itamae"/) }
+end
+
+describe file('/tmp/http_request_another_ordinary.html') do
+  it { should be_file }
+  it { should be_owned_by "itamae" }
+  it { should be_grouped_into "itamae" }
+  its(:content) { should match(/"from":\s*"itamae"/) }
+end

--- a/spec/integration/ordinary_user_spec.rb
+++ b/spec/integration/ordinary_user_spec.rb
@@ -14,12 +14,16 @@ describe file('/tmp/remote_file_root') do
   its(:content) { should match(/Hello Itamae/) }
 end
 
-describe file('/tmp/remote_file_another_ordinary') do
-  it { should be_file }
-  it { should be_owned_by "itamae" }
-  it { should be_grouped_into "itamae" }
-  its(:content) { should match(/Hello Itamae/) }
+%w[/tmp/remote_file_another_ordinary /tmp/remote_file_another_ordinary_with_root].each do |path|
+  describe file(path) do
+    it { should be_file }
+    it { should be_owned_by "itamae" }
+    it { should be_grouped_into "itamae" }
+    its(:content) { should match(/Hello Itamae/) }
+  end
 end
+
+###
 
 describe file('/tmp/file') do
   it { should be_file }
@@ -35,12 +39,16 @@ describe file('/tmp/file_root') do
   its(:content) { should match(/Hello World/) }
 end
 
-describe file('/tmp/file_another_ordinary') do
-  it { should be_file }
-  it { should be_owned_by "itamae" }
-  it { should be_grouped_into "itamae" }
-  its(:content) { should match(/Hello World/) }
+%w[/tmp/file_another_ordinary /tmp/file_another_ordinary_with_root].each do |path|
+  describe file(path) do
+    it { should be_file }
+    it { should be_owned_by "itamae" }
+    it { should be_grouped_into "itamae" }
+    its(:content) { should match(/Hello World/) }
+  end
 end
+
+###
 
 describe file('/tmp/template') do
   it { should be_file }
@@ -62,15 +70,19 @@ describe file('/tmp/template_root') do
   its(:content) { should match(/^uninitialized node key: $/) }
 end
 
-describe file('/tmp/template_another_ordinary') do
-  it { should be_file }
-  it { should be_owned_by "itamae" }
-  it { should be_grouped_into "itamae" }
-  its(:content) { should match(/Hello/) }
-  its(:content) { should match(/Good bye/) }
-  its(:content) { should match(/^total memory: \d+kB$/) }
-  its(:content) { should match(/^uninitialized node key: $/) }
+%w[/tmp/template_another_ordinary /tmp/template_another_ordinary_with_root].each do |path|
+  describe file(path) do
+    it { should be_file }
+    it { should be_owned_by "itamae" }
+    it { should be_grouped_into "itamae" }
+    its(:content) { should match(/Hello/) }
+    its(:content) { should match(/Good bye/) }
+    its(:content) { should match(/^total memory: \d+kB$/) }
+    its(:content) { should match(/^uninitialized node key: $/) }
+  end
 end
+
+###
 
 describe file('/tmp/http_request.html') do
   it { should be_file }
@@ -86,9 +98,11 @@ describe file('/tmp/http_request_root.html') do
   its(:content) { should match(/"from":\s*"itamae"/) }
 end
 
-describe file('/tmp/http_request_another_ordinary.html') do
-  it { should be_file }
-  it { should be_owned_by "itamae" }
-  it { should be_grouped_into "itamae" }
-  its(:content) { should match(/"from":\s*"itamae"/) }
+%w[/tmp/http_request_another_ordinary.html /tmp/http_request_another_ordinary_with_root.html].each do |path|
+  describe file(path) do
+    it { should be_file }
+    it { should be_owned_by "itamae" }
+    it { should be_grouped_into "itamae" }
+    its(:content) { should match(/"from":\s*"itamae"/) }
+  end
 end

--- a/spec/integration/recipes/local.rb
+++ b/spec/integration/recipes/local.rb
@@ -8,3 +8,14 @@ gem_package 'ast' do
   version '2.0.0'
   options ['--no-document']
 end
+
+######
+
+# Docker backend raises an error with `user` option, so it tests only on `itamae local`.
+# After fix this error, please move this code and the spec to `default.rb`.
+file "/tmp/file_as_ordinary_user" do
+  content "Hello World"
+  user "itamae"
+  owner "itamae"
+  group "itamae"
+end

--- a/spec/integration/recipes/ordinary_user.rb
+++ b/spec/integration/recipes/ordinary_user.rb
@@ -1,0 +1,91 @@
+user "create another ordinary user" do
+  user 'root'
+  uid 123
+  username "itamae"
+  password "$1$ltOY8bZv$iZ57f1KAp8jwKViNm3pze."
+  home '/home/foo'
+  shell '/bin/sh'
+end
+
+###
+
+remote_file "/tmp/remote_file" do
+  source "hello.txt"
+end
+
+remote_file "/tmp/remote_file_root" do
+  user 'root'
+  owner 'root'
+  group 'root'
+  source "hello.txt"
+end
+
+remote_file "/tmp/remote_file_another_ordinary" do
+  user 'root'
+  owner 'itamae'
+  group 'itamae'
+  source "hello.txt"
+end
+
+###
+
+file "/tmp/file" do
+  content "Hello World"
+end
+
+file "/tmp/file_root" do
+  user 'root'
+  owner 'root'
+  group 'root'
+  content 'Hello World'
+end
+
+file "/tmp/file_another_ordinary" do
+  user 'root'
+  owner 'itamae'
+  group 'itamae'
+  content 'Hello World'
+end
+
+###
+
+template "/tmp/template" do
+  source "hello.erb"
+  variables goodbye: "Good bye"
+end
+
+template "/tmp/template_root" do
+  user 'root'
+  owner 'root'
+  group 'root'
+  source "hello.erb"
+  variables goodbye: "Good bye"
+end
+
+template "/tmp/template_another_ordinary" do
+  user 'root'
+  owner 'itamae'
+  group 'itamae'
+  source "hello.erb"
+  variables goodbye: "Good bye"
+end
+
+###
+
+http_request "/tmp/http_request.html" do
+  url "https://httpbin.org/get?from=itamae"
+end
+
+http_request "/tmp/http_request_root.html" do
+  user 'root'
+  owner 'root'
+  group 'root'
+  url "https://httpbin.org/get?from=itamae"
+end
+
+http_request "/tmp/http_request_another_ordinary.html" do
+  user 'root'
+  owner 'itamae'
+  group 'itamae'
+  url "https://httpbin.org/get?from=itamae"
+end

--- a/spec/integration/recipes/ordinary_user.rb
+++ b/spec/integration/recipes/ordinary_user.rb
@@ -1,14 +1,3 @@
-user "create another ordinary user" do
-  user 'root'
-  uid 123
-  username "itamae"
-  password "$1$ltOY8bZv$iZ57f1KAp8jwKViNm3pze."
-  home '/home/foo'
-  shell '/bin/sh'
-end
-
-###
-
 remote_file "/tmp/remote_file" do
   source "hello.txt"
 end
@@ -21,6 +10,13 @@ remote_file "/tmp/remote_file_root" do
 end
 
 remote_file "/tmp/remote_file_another_ordinary" do
+  user 'itamae'
+  owner 'itamae'
+  group 'itamae'
+  source "hello.txt"
+end
+
+remote_file "/tmp/remote_file_another_ordinary_with_root" do
   user 'root'
   owner 'itamae'
   group 'itamae'
@@ -41,6 +37,13 @@ file "/tmp/file_root" do
 end
 
 file "/tmp/file_another_ordinary" do
+  user 'itamae'
+  owner 'itamae'
+  group 'itamae'
+  content 'Hello World'
+end
+
+file "/tmp/file_another_ordinary_with_root" do
   user 'root'
   owner 'itamae'
   group 'itamae'
@@ -63,6 +66,14 @@ template "/tmp/template_root" do
 end
 
 template "/tmp/template_another_ordinary" do
+  user 'itamae'
+  owner 'itamae'
+  group 'itamae'
+  source "hello.erb"
+  variables goodbye: "Good bye"
+end
+
+template "/tmp/template_another_ordinary_with_root" do
   user 'root'
   owner 'itamae'
   group 'itamae'
@@ -84,6 +95,13 @@ http_request "/tmp/http_request_root.html" do
 end
 
 http_request "/tmp/http_request_another_ordinary.html" do
+  user 'itamae'
+  owner 'itamae'
+  group 'itamae'
+  url "https://httpbin.org/get?from=itamae"
+end
+
+http_request "/tmp/http_request_another_ordinary_with_root.html" do
   user 'root'
   owner 'itamae'
   group 'itamae'

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -50,7 +50,8 @@ namespace 'spec:integration:local' do
       user: 'ordinary_san'
     )
     runner.docker_exec 'useradd', 'ordinary_san', '-p', '*'
-    runner.docker_exec 'sh', '-c', 'echo "ordinary_san ALL=NOPASSWD: ALL" >> /etc/sudoers'
+    runner.docker_exec 'useradd', 'itamae', '-p', '*', '--create-home'
+    runner.docker_exec 'sh', '-c', 'echo "ordinary_san ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers'
     runner.run
   end
 end

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -1,6 +1,10 @@
 desc 'Run integration test on `itamae local` command'
 task 'spec:integration:local' do
-  next if RUBY_DESCRIPTION.include?('dev')
+  if RUBY_DESCRIPTION.include?('dev')
+    $stderr.puts "This integration test is skipped with unreleased Ruby."
+    $stderr.puts "Use released Ruby to execute this integration test."
+    next
+  end
 
   IntegrationLocalSpecRunner.new(
     [


### PR DESCRIPTION
Problem
===


`user` option does not work with `file`, `remote_file` and so on resources.
Probably other resouces have similar problems, but I've not confirm them yet. I describe the similar problems in the Cause section.


## background

I'd like to execute itamae process with an ordinary user, but I'd like to put files that are owned by the root user.
When itamae needs the root user, I want to write `user 'root'` explicitly, and I want to use `sudo` command only if itamae needs the root user.

For instance, I'd like to use Itamae to provision a desktop computer for development. In this case, I'd like to put some files that is owned by an ordinary user (e.g. `~/.vimrc`), and owned by the root user (e.g. `/etc/hosts`) too.
Unfortunately I cannot execute Itamae on the background.
I investigated this problem, and I describe this problem in this pull request.



## Related issues

* https://github.com/itamae-kitchen/itamae/issues/214
* https://github.com/itamae-kitchen/itamae/issues/220
* https://github.com/k0kubun/itamae-plugin-recipe-rbenv/issues/14
* https://github.com/itamae-kitchen/itamae/pull/221

The first three issues mention the same problem, so I think we can close these issues by this pull request.
The last issue is a pull request for this problem, but I think the patch is not appropriate because the same reason as the sorah's comment. So we need another solution for this problem.




Reproduce
---



`test.rb`

```ruby
file 'a' do
  user 'root'
  path '/a'
  content 'a'
end
```

```shell
$ itamae version
Itamae v1.10.2

$ itamae local test.rb
 INFO : Starting Itamae...
 INFO : Recipe: /tmp/tmp.LeJHTLb9B9/test.rb
[sudo] password for pocke: # <Enter the password>
Traceback (most recent call last):
	51: from /home/pocke/.rbenv/versions/trunk/bin/itamae:23:in `<main>'
	50: from /home/pocke/.rbenv/versions/trunk/bin/itamae:23:in `load'
	49: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/bin/itamae:4:in `<top (required)>'
	48: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
	47: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
	46: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
	45: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
	44: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/cli.rb:37:in `local'
	43: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/cli.rb:137:in `run'
	42: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/runner.rb:14:in `run'
	41: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/runner.rb:61:in `run'
	40: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/recipe_children.rb:57:in `run'
	39: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/recipe_children.rb:57:in `each'
	38: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/recipe_children.rb:58:in `block in run'
	37: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/recipe.rb:64:in `run'
	36: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/handler_proxy.rb:13:in `event'
	35: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/handler_proxy.rb:29:in `_event_with_block'
	34: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/recipe.rb:65:in `block in run'
	33: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/logger.rb:10:in `with_indent'
	32: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/recipe.rb:66:in `block (2 levels) in run'
	31: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/recipe_children.rb:57:in `run'
	30: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/recipe_children.rb:57:in `each'
	29: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/recipe_children.rb:58:in `block in run'
	28: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/resource/base.rb:124:in `run'
	27: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/handler_proxy.rb:13:in `event'
	26: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/handler_proxy.rb:29:in `_event_with_block'
	25: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/resource/base.rb:127:in `block in run'
	24: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/logger.rb:19:in `with_indent_if'
	23: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/resource/base.rb:136:in `block (2 levels) in run'
	22: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/resource/base.rb:136:in `each'
	21: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/resource/base.rb:137:in `block (3 levels) in run'
	20: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/resource/base.rb:178:in `run_action'
	19: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/handler_proxy.rb:13:in `event'
	18: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/handler_proxy.rb:29:in `_event_with_block'
	17: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/resource/base.rb:188:in `block in run_action'
	16: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/logger.rb:19:in `with_indent_if'
	15: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/resource/base.rb:190:in `block (2 levels) in run_action'
	14: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/resource/file.rb:32:in `pre_action'
	13: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/resource/file.rb:191:in `send_tempfile'
	12: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.2/lib/itamae/backend.rb:109:in `send_file'
	11: from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/specinfra-2.76.5/lib/specinfra/backend/exec.rb:25:in `send_file'
	10: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/fileutils.rb:418:in `cp'
	 9: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/fileutils.rb:1555:in `fu_each_src_dest'
	 8: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/fileutils.rb:1573:in `fu_each_src_dest0'
	 7: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/fileutils.rb:1557:in `block in fu_each_src_dest'
	 6: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/fileutils.rb:419:in `block in cp'
	 5: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/fileutils.rb:492:in `copy_file'
	 4: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/fileutils.rb:1385:in `copy_file'
	 3: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/fileutils.rb:1385:in `open'
	 2: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/fileutils.rb:1386:in `block in copy_file'
	 1: from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/fileutils.rb:1386:in `open'
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/fileutils.rb:1386:in `initialize': Permission denied @ rb_sysopen - /tmp/itamae_tmp/1545847140.9009516 (Errno::EACCES)
```

Sorah says "Why not using owner attribute instead of user?" in this comment ( https://github.com/itamae-kitchen/itamae/pull/221#issuecomment-256426713 ), but the suggestion raises another error in this case.

`test.rb`

```ruby
file 'a' do
  owner 'root'
  path '/a'
  content 'a'
end
```

```shell
$ itamae local test.rb
 INFO : Starting Itamae... 
 INFO : Recipe: /tmp/tmp.LeJHTLb9B9/test.rb
 INFO :   file[a] exist will change from 'false' to 'true'
 INFO :   file[a] modified will change from 'false' to 'true'
 INFO :   file[a] owner will be 'root'
 INFO :   diff:
 INFO :   --- /dev/null	2018-12-11 08:30:42.354322279 +0900
 INFO :   +++ /tmp/itamae_tmp/1545849545.8678365	2018-12-27 03:39:05.872209770 +0900
 INFO :   @@ -0,0 +1 @@
 INFO :   +a
 INFO :   \ No newline at end of file
ERROR :     stderr | chown: changing ownership of '/tmp/itamae_tmp/1545849545.8678365': Operation not permitted
ERROR :     Command `chown root /tmp/itamae_tmp/1545849545.8678365` failed. (exit status: 1)
ERROR :   file[a] Failed.
```

Itamae changes the owner of the file to specified user by `owner` option, which is the root user, but executed user is an ordinary user so the user does not have the permission to chown.

I think I need the following code for expected behaviour. But it also raises the same error as the first code.

```ruby
file 'a' do
  user 'root' # need permission for chown this file
  owner 'root' # need to specify the owner
  group 'root' # need to specify the group
  path '/a'
  content 'a'
end
```
 







Cause
===

In short, because `send_file` is not aware of `user` option.

The error is occurred in `lib/itamae/backend.rb:109` in `send_file` method.
https://github.com/itamae-kitchen/itamae/blob/452e105faa72cef3000b11c6bab29764d6e2d37e/lib/itamae/backend.rb#L109
It calls `Specinfra::Backend::XXX#send_file`. The `XXX` is `Exec`, `SSH`, `Docker`, and so on. When it is `Exec`, which Itamae::Backend` is `Local`, `send_file` method calls `FileUtils.cp` method. 
https://github.com/mizzy/specinfra/blob/d3c00a0076c7ef86d28e22ac545f69db7c031d70/lib/specinfra/backend/exec.rb#L24-L26

`FileUtils.cp` is a Ruby method, not an external command. So it is not aware of `user` option. It's simply called in an itamae process, so itamae does not change user.


By the way, I wrote " I describe the similar problems in the Cause section." in the first section of this pull request.
Itamae has similar code, so I guess there are similar problems.
For example, `Backend#send_directory` medhod also calls `FileUtils` method.
https://github.com/itamae-kitchen/itamae/blob/425b9f7e8007ed19ed649789b8d1c2d7e64b1fcc/lib/itamae/backend.rb#L112-L121
https://github.com/mizzy/specinfra/blob/d3c00a0076c7ef86d28e22ac545f69db7c031d70/lib/specinfra/backend/exec.rb#L28-L30
I also find `receive_file` method that is monkeypatched by Itamae.
https://github.com/itamae-kitchen/itamae/blob/425b9f7e8007ed19ed649789b8d1c2d7e64b1fcc/lib/itamae/ext/specinfra.rb#L11-L19

Maybe we need to fix them, but this pull request does not change them. It only focuses `send_file` method.
Because I do not use other than `send_file` method, so I do not have motivation to fix these method.



Solution
===


Use an external command for `send_file` method. See the diff!

Update 2019-01-16: This description is incomplete. Please read this comment also. https://github.com/itamae-kitchen/itamae/pull/277#issuecomment-454714201


Note
====

This patch does not add any test cases. I'm not sure how to test this patch. I think we should add an integration test case for this change, but the integration test works only with docker. So I cannot add an integration test case for `itamae local` command.
If you have a good solution for test, please tell me it. I'd like to write test for this problem.

I guess we can execute the integration test in the docker image, but with `itamae local` command also. For examle, `docker run ubuntu:trusty -v $(pwd):/itamae /itamae/bin/itamae local ...` (this command is simplified).

note: I've confirmed the patch works well in my environment.
