### PR TITLE
Add integration test with `itamae local` command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 sudo: required
+dist: xenial
 services:
   - docker
 rvm:

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ namespace :spec do
     targets = ["ubuntu:trusty"]
     container_name = 'itamae'
 
-    task :all     => targets
+    task :all     => targets + ['spec:integration:local']
 
     targets.each do |target|
       desc "Run provision and specs to #{target}"

--- a/Rakefile
+++ b/Rakefile
@@ -69,7 +69,7 @@ namespace :spec do
         RSpec::Core::RakeTask.new(target.to_sym) do |t|
           ENV['DOCKER_CONTAINER'] = container_name
           t.ruby_opts = '-I ./spec/integration'
-          t.pattern = "spec/integration/*_spec.rb"
+          t.pattern = "spec/integration/[default|docker]_spec.rb"
         end
       end
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,10 @@ require 'rspec/core/rake_task'
 require 'tempfile'
 require 'net/ssh'
 
+Dir['tasks/*.rb'].each do |file|
+  require_relative file
+end
+
 desc 'Run unit and integration specs.'
 task :spec => ['spec:unit', 'spec:integration:all']
 

--- a/Rakefile
+++ b/Rakefile
@@ -41,6 +41,7 @@ namespace :spec do
               "spec/integration/recipes/default.rb",
               "spec/integration/recipes/default2.rb",
               "spec/integration/recipes/redefine.rb",
+              "spec/integration/recipes/docker.rb",
             ],
             [
               "--dry-run",

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -119,34 +119,6 @@ describe file('/tmp/subscribes') do
   its(:content) { should eq("2431") }
 end
 
-describe file('/tmp/cron_stopped') do
-  it { should be_file }
-  its(:content) do
-    expect(subject.content.lines.size).to eq 1
-  end
-end
-
-# FIXME: cron service is not running in docker...
-#
-# root@3450c6da6ea5:/# ps -C cron
-#   PID TTY          TIME CMD
-# root@3450c6da6ea5:/# service cron start
-# Rather than invoking init scripts through /etc/init.d, use the service(8)
-# utility, e.g. service cron start
-#
-# Since the script you are attempting to invoke has been converted to an
-# Upstart job, you may also use the start(8) utility, e.g. start cron
-# root@3450c6da6ea5:/# ps -C cron
-#   PID TTY          TIME CMD
-# root@3450c6da6ea5:/#
-
-# describe file('/tmp/cron_running') do
-#   it { should be_file }
-#   its(:content) do
-#     expect(subject.content.lines.size).to eq 2
-#   end
-# end
-
 describe file('/tmp-link') do
   it { should be_linked_to '/tmp' }
   its(:content) do
@@ -206,7 +178,7 @@ describe command('gem list') do
 end
 
 describe command('gem list') do
-  its(:stdout) { should include('rake (11.1.0)') }
+  its(:stdout) { should match(/^rake \(.*11.1.0.*\)/) }
 end
 
 describe command('gem list') do

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -185,8 +185,12 @@ describe command('gem list') do
   its(:stdout) { should_not include('test-unit') }
 end
 
-describe command('ri Bundler') do
-  its(:stderr) { should eq("Nothing known about Bundler\n") }
+describe command('gem list') do
+  its(:stdout) { should include('ast (2.0.0)') }
+end
+
+describe command('ri AST') do
+  its(:stderr) { should eq("Nothing known about AST\n") }
 end
 
 describe file('/tmp/created_by_definition') do

--- a/spec/integration/docker_spec.rb
+++ b/spec/integration/docker_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe file('/tmp/cron_stopped') do
+  it { should be_file }
+  its(:content) do
+    expect(subject.content.lines.size).to eq 1
+  end
+end
+
+# FIXME: cron service is not running in docker...
+#
+# root@3450c6da6ea5:/# ps -C cron
+#   PID TTY          TIME CMD
+# root@3450c6da6ea5:/# service cron start
+# Rather than invoking init scripts through /etc/init.d, use the service(8)
+# utility, e.g. service cron start
+#
+# Since the script you are attempting to invoke has been converted to an
+# Upstart job, you may also use the start(8) utility, e.g. start cron
+# root@3450c6da6ea5:/# ps -C cron
+#   PID TTY          TIME CMD
+# root@3450c6da6ea5:/#
+
+# describe file('/tmp/cron_running') do
+#   it { should be_file }
+#   its(:content) do
+#     expect(subject.content.lines.size).to eq 2
+#   end
+# end

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -45,10 +45,6 @@ package 'dstat' do
   action :install
 end
 
-package 'sl' do
-  version '3.03-17'
-end
-
 package 'resolvconf' do
   action :remove
 end
@@ -63,11 +59,6 @@ end
 
 gem_package 'tzinfo' do
   version '1.2.2'
-end
-
-gem_package 'bundler' do
-  version '1.17.3'
-  options ['--no-ri', '--no-rdoc']
 end
 
 gem_package 'rake' do
@@ -223,42 +214,6 @@ http_request "/tmp/http_request_redirect.html" do
   redirect_limit 1
   url "https://httpbin.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fget%3Ffrom%3Ditamae"
 end
-
-######
-
-service "cron" do
-  action :stop
-end
-
-execute "ps -C cron > /tmp/cron_stopped; true"
-
-service "cron" do
-  action :start
-end
-
-execute "ps -C cron > /tmp/cron_running; true"
-
-######
-
-package "nginx" do
-  options "--force-yes"
-end
-
-service "nginx" do
-  action [:enable, :start]
-end
-
-execute "test -f /etc/rc3.d/S20nginx" # test
-execute "test $(ps h -C nginx | wc -l) -gt 0" # test
-
-service "nginx" do
-  action [:disable, :stop]
-end
-
-execute "test ! -f /etc/rc3.d/S20nginx" # test
-execute "test $(ps h -C nginx | wc -l) -eq 0" # test
-
-######
 
 link "/tmp-link" do
   to "/tmp"

--- a/spec/integration/recipes/docker.rb
+++ b/spec/integration/recipes/docker.rb
@@ -4,8 +4,8 @@ end
 
 ######
 
-gem_package 'bundler' do
-  version '1.17.3'
+gem_package 'ast' do
+  version '2.0.0'
   options ['--no-ri', '--no-rdoc']
 end
 

--- a/spec/integration/recipes/docker.rb
+++ b/spec/integration/recipes/docker.rb
@@ -1,0 +1,44 @@
+package 'sl' do
+  version '3.03-17'
+end
+
+######
+
+gem_package 'bundler' do
+  version '1.17.3'
+  options ['--no-ri', '--no-rdoc']
+end
+
+######
+
+service "cron" do
+  action :stop
+end
+
+execute "ps -C cron > /tmp/cron_stopped; true"
+
+service "cron" do
+  action :start
+end
+
+execute "ps -C cron > /tmp/cron_running; true"
+
+######
+
+package "nginx" do
+  options "--force-yes"
+end
+
+service "nginx" do
+  action [:enable, :start]
+end
+
+execute "test -f /etc/rc3.d/S20nginx" # test
+execute "test $(ps h -C nginx | wc -l) -gt 0" # test
+
+service "nginx" do
+  action [:disable, :stop]
+end
+
+execute "test ! -f /etc/rc3.d/S20nginx" # test
+execute "test $(ps h -C nginx | wc -l) -eq 0" # test

--- a/spec/integration/recipes/local.rb
+++ b/spec/integration/recipes/local.rb
@@ -4,7 +4,7 @@ end
 
 ######
 
-gem_package 'bundler' do
-  version '1.17.3'
+gem_package 'ast' do
+  version '2.0.0'
   options ['--no-document']
 end

--- a/spec/integration/recipes/local.rb
+++ b/spec/integration/recipes/local.rb
@@ -1,0 +1,10 @@
+package 'sl' do
+  version '3.03-17+b2'
+end
+
+######
+
+gem_package 'bundler' do
+  version '1.17.3'
+  options ['--no-document']
+end

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -13,7 +13,7 @@ task 'spec:integration:local' do
         "spec/integration/recipes/dry_run.rb",
       ],
     ],
-    Dir['spec/integration/*_spec.rb']
+    ['spec/integration/default_spec.rb']
   ).run
 end
 

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -70,7 +70,7 @@ class IntegrationLocalSpecRunner
   end
 
   def clean_docker_container
-    sh('docker', 'rm', '-f', @container_name)
+    sh('docker', 'rm', '-f', CONTAINER_NAME)
   end
 
   def docker_exec(*cmd, options: [])

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -6,6 +6,7 @@ task 'spec:integration:local' do
         "spec/integration/recipes/default.rb",
         "spec/integration/recipes/default2.rb",
         "spec/integration/recipes/redefine.rb",
+        "spec/integration/recipes/local.rb",
       ],
       [
         "--dry-run",

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -37,19 +37,7 @@ class IntegrationLocalSpecRunner
 
   def docker_run
     mount_dir = Pathname(__dir__).join('../').to_s
-    if container_alive?
-      raise "Docker container is already running. Please stop the container with `docker rm -f #{CONTAINER_NAME}`"
-    end
-
-    Thread.new do
-      begin
-        sh 'docker', 'run', '--privileged', '--name', CONTAINER_NAME, '-v', "#{mount_dir}:/itamae", "ruby:#{@ruby_version}", 'sleep', '1d'
-      rescue RuntimeError
-        # Suppress RuntimeError because it occurred by clean_docker_container
-      end
-    end
-
-    sleep 0.5 until container_alive?
+    sh 'docker', 'run', '--privileged', '-d', '--name', CONTAINER_NAME, '-v', "#{mount_dir}:/itamae", "ruby:#{@ruby_version}", 'sleep', '1d'
   end
 
   def prepare
@@ -82,9 +70,5 @@ class IntegrationLocalSpecRunner
 
   def docker_exec(*cmd, options: [])
     sh 'docker', 'exec', '--env', 'LANG=en_US.utf8', *options, CONTAINER_NAME, *cmd
-  end
-
-  def container_alive?
-    `docker ps` =~ /itamae$/
   end
 end

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -1,0 +1,77 @@
+desc 'Run integration test on `itamae local` command'
+task 'spec:integration:local' do
+  IntegrationLocalSpecRunner.new(
+    [
+      [
+        "spec/integration/recipes/default.rb",
+        "spec/integration/recipes/default2.rb",
+        "spec/integration/recipes/redefine.rb",
+      ],
+      [
+        "--dry-run",
+        "spec/integration/recipes/dry_run.rb",
+      ],
+    ],
+    Dir['spec/integration/*_spec.rb']
+  ).run
+end
+
+class IntegrationLocalSpecRunner
+  CONTAINER_NAME = 'itamae'
+  include FileUtils
+
+  def initialize(suites, specs)
+    @suites = suites
+    @specs = specs
+  end
+
+  def run
+    docker_run
+    prepare
+    provision
+    serverspec
+    clean_docker_container
+  end
+
+  def docker_run
+    mount_dir = Pathname(__dir__).join('../').to_s
+    Thread.new do
+      Thread.current.abort_on_exception = true
+      sh 'docker', 'run', '--privileged', '--name', CONTAINER_NAME, '-v', "#{mount_dir}:/itamae", "ruby:#{RUBY_VERSION}", 'sleep', '1d'
+    end
+    
+    sleep 0.5 until `docker ps` =~ /itamae$/
+  end
+
+  def prepare
+    docker_exec 'gem', 'install', 'bundler'
+    docker_exec 'bundle', 'install', options: %w[--workdir /itamae]
+    docker_exec 'apt-get', 'update', '-y'
+    docker_exec 'apt-get', 'install', 'locales', 'sudo', '-y'
+    docker_exec 'localedef', '-i', 'en_US', '-c', '-f', 'UTF-8', '-A', '/usr/share/locale/locale.alias', 'en_US.UTF-8'
+  end
+
+  def provision
+    @suites.each do |suite|
+      cmd = %W!bundle exec ruby -w bin/itamae local!
+      cmd << "-l" << (ENV['LOG_LEVEL'] || 'debug')
+      cmd << "-j" << "spec/integration/recipes/node.json"
+      cmd += suite
+
+      docker_exec(*cmd, options: %w[--workdir /itamae])
+    end
+  end
+
+  def serverspec
+    ENV['DOCKER_CONTAINER'] = CONTAINER_NAME
+    sh('bundle', 'exec', 'rspec', '-I', './spec/integration', *@specs)
+  end
+
+  def clean_docker_container
+    sh('docker', 'rm', '-f', @container_name)
+  end
+
+  def docker_exec(*cmd, options: [])
+    sh 'docker', 'exec', '--env', 'LANG=en_US.utf8', *options, CONTAINER_NAME, *cmd
+  end
+end

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -20,9 +20,10 @@ class IntegrationLocalSpecRunner
   CONTAINER_NAME = 'itamae'
   include FileUtils
 
-  def initialize(suites, specs)
+  def initialize(suites, specs, ruby_version: RUBY_VERSION)
     @suites = suites
     @specs = specs
+    @ruby_version = ruby_version
   end
 
   def run
@@ -37,7 +38,7 @@ class IntegrationLocalSpecRunner
     mount_dir = Pathname(__dir__).join('../').to_s
     Thread.new do
       Thread.current.abort_on_exception = true
-      sh 'docker', 'run', '--privileged', '--name', CONTAINER_NAME, '-v', "#{mount_dir}:/itamae", "ruby:#{RUBY_VERSION}", 'sleep', '1d'
+      sh 'docker', 'run', '--privileged', '--name', CONTAINER_NAME, '-v', "#{mount_dir}:/itamae", "ruby:#{@ruby_version}", 'sleep', '1d'
     end
     
     sleep 0.5 until `docker ps` =~ /itamae$/

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -21,7 +21,7 @@ class IntegrationLocalSpecRunner
   CONTAINER_NAME = 'itamae'
   include FileUtils
 
-  def initialize(suites, specs, ruby_version: RUBY_VERSION)
+  def initialize(suites, specs, ruby_version: RUBY_VERSION.split('.')[0..1].join('.'))
     @suites = suites
     @specs = specs
     @ruby_version = ruby_version

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -37,12 +37,19 @@ class IntegrationLocalSpecRunner
 
   def docker_run
     mount_dir = Pathname(__dir__).join('../').to_s
-    Thread.new do
-      Thread.current.abort_on_exception = true
-      sh 'docker', 'run', '--privileged', '--name', CONTAINER_NAME, '-v', "#{mount_dir}:/itamae", "ruby:#{@ruby_version}", 'sleep', '1d'
+    if container_alive?
+      raise "Docker container is already running. Please stop the container with `docker rm -f #{CONTAINER_NAME}`"
     end
-    
-    sleep 0.5 until `docker ps` =~ /itamae$/
+
+    Thread.new do
+      begin
+        sh 'docker', 'run', '--privileged', '--name', CONTAINER_NAME, '-v', "#{mount_dir}:/itamae", "ruby:#{@ruby_version}", 'sleep', '1d'
+      rescue RuntimeError
+        # Suppress RuntimeError because it occurred by clean_docker_container
+      end
+    end
+
+    sleep 0.5 until container_alive?
   end
 
   def prepare
@@ -75,5 +82,9 @@ class IntegrationLocalSpecRunner
 
   def docker_exec(*cmd, options: [])
     sh 'docker', 'exec', '--env', 'LANG=en_US.utf8', *options, CONTAINER_NAME, *cmd
+  end
+
+  def container_alive?
+    `docker ps` =~ /itamae$/
   end
 end

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -1,5 +1,7 @@
 desc 'Run integration test on `itamae local` command'
 task 'spec:integration:local' do
+  next if RUBY_DESCRIPTION.include?('dev')
+
   IntegrationLocalSpecRunner.new(
     [
       [


### PR DESCRIPTION
Problem
===


We don't have any integration test for `itamae local` command, so we cannot test #277.


Solution
====


Add an integation test for `itamae local` command.

Strategy:

1. Start a docker container for the test.
1. Execute `itamae local` comamnd in the container.
1. Execute the serverspec from the host machine.





Goal of this pull request
==


- [x] Add integration test script.
- [x] Run this test on CI
- [x] Make the test cases green with `itamae local` also
- [ ] Add test case for #277 (maybe I should work this todo on #277 )



