### PR TITLE
Suppress Ruby warnings

### DIFF
--- a/lib/itamae/definition.rb
+++ b/lib/itamae/definition.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   class Definition < Resource::Base
     class << self

--- a/lib/itamae/logger.rb
+++ b/lib/itamae/logger.rb
@@ -1,4 +1,3 @@
-require 'itamae'
 require 'logger'
 require 'ansi/code'
 

--- a/lib/itamae/logger.rb
+++ b/lib/itamae/logger.rb
@@ -71,6 +71,10 @@ module Itamae
     class Formatter
       attr_accessor :colored
 
+      def initialize
+        @color = nil
+      end
+
       def call(severity, datetime, progname, msg)
         log = "%s : %s" % ["%5s" % severity, msg2str(msg)]
 

--- a/lib/itamae/node.rb
+++ b/lib/itamae/node.rb
@@ -1,4 +1,3 @@
-require 'itamae'
 require 'hashie'
 require 'json'
 require 'schash'

--- a/lib/itamae/notification.rb
+++ b/lib/itamae/notification.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   class Notification < Struct.new(:defined_in_resource, :action, :target_resource_desc, :timing)
     def self.create(*args)

--- a/lib/itamae/recipe.rb
+++ b/lib/itamae/recipe.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   class Recipe
     NotFoundError = Class.new(StandardError)

--- a/lib/itamae/resource.rb
+++ b/lib/itamae/resource.rb
@@ -1,4 +1,3 @@
-require 'itamae'
 require 'itamae/resource/base'
 require 'itamae/resource/file'
 require 'itamae/resource/package'

--- a/lib/itamae/resource/base.rb
+++ b/lib/itamae/resource/base.rb
@@ -1,4 +1,3 @@
-require 'itamae'
 require 'shellwords'
 require 'hashie'
 

--- a/lib/itamae/resource/directory.rb
+++ b/lib/itamae/resource/directory.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class Directory < Base

--- a/lib/itamae/resource/execute.rb
+++ b/lib/itamae/resource/execute.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class Execute < Base

--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class File < Base

--- a/lib/itamae/resource/gem_package.rb
+++ b/lib/itamae/resource/gem_package.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class GemPackage < Base

--- a/lib/itamae/resource/git.rb
+++ b/lib/itamae/resource/git.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class Git < Base

--- a/lib/itamae/resource/group.rb
+++ b/lib/itamae/resource/group.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class Group < Base

--- a/lib/itamae/resource/http_request.rb
+++ b/lib/itamae/resource/http_request.rb
@@ -1,4 +1,3 @@
-require 'itamae'
 require 'uri'
 require 'net/https'
 

--- a/lib/itamae/resource/link.rb
+++ b/lib/itamae/resource/link.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class Link < Base

--- a/lib/itamae/resource/local_ruby_block.rb
+++ b/lib/itamae/resource/local_ruby_block.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class LocalRubyBlock < Base

--- a/lib/itamae/resource/package.rb
+++ b/lib/itamae/resource/package.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class Package < Base

--- a/lib/itamae/resource/remote_directory.rb
+++ b/lib/itamae/resource/remote_directory.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class RemoteDirectory < Base

--- a/lib/itamae/resource/remote_file.rb
+++ b/lib/itamae/resource/remote_file.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class RemoteFile < File

--- a/lib/itamae/resource/service.rb
+++ b/lib/itamae/resource/service.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class Service < Base

--- a/lib/itamae/resource/template.rb
+++ b/lib/itamae/resource/template.rb
@@ -1,4 +1,3 @@
-require 'itamae'
 require 'erb'
 require 'tempfile'
 

--- a/lib/itamae/resource/user.rb
+++ b/lib/itamae/resource/user.rb
@@ -1,5 +1,3 @@
-require 'itamae'
-
 module Itamae
   module Resource
     class User < Base

--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -1,4 +1,3 @@
-require 'itamae'
 require 'json'
 require 'yaml'
 


### PR DESCRIPTION


With `RUBYOPT=-w`, Ruby reports some warnings of Itamae.
This pull request will suppress two warnings.

* circular require  aea48c1
* Uninitialized instance variable 824dd1e

Please read each commit message to know what the commit changes.


Note: Ruby still warns with this pull request, but the warnings are for dependencies (e.g. specinfra). So we should fix the dependencies to avoid all warnings.