### PR TITLE
Add description to --tag option of docker subcommand

### DIFF
--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -64,7 +64,7 @@ module Itamae
     option :image, type: :string, desc: "This option or 'container' option is required."
     option :container, type: :string, desc: "This option or 'image' option is required."
     option :tls_verify_peer, type: :boolean, default: true
-    option :tag, type: :string
+    option :tag, type: :string, desc: 'Tag name of created docker image.'
     def docker(*recipe_files)
       if recipe_files.empty?
         raise "Please specify recipe files."


### PR DESCRIPTION
I think `--tag` option name is not descriptive. I did not understand the option behavior without reading the implementation.
So adding a description to the option is helpful.