### PR TITLE
Suppress Ruby warning

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -9,7 +9,7 @@ module Specinfra
   module Configuration
     def self.sudo_password
       return ENV['SUDO_PASSWORD'] if ENV['SUDO_PASSWORD']
-      return @sudo_password if @sudo_password
+      return @sudo_password if defined?(@sudo_password)
 
       # TODO: Fix this dirty hack
       return nil unless caller.any? {|call| call.include?('channel_data') }


### PR DESCRIPTION
`itamae ssh` command displays many warnings when `RUBYOPT=-w` is passed.

```
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/itamae-1.10.3/lib/itamae/backend.rb:12: warning: instance variable @sudo_password not initialized
```

This patch suppresses the warnings.