### PR TITLE
Refine `itamae docker`'s created message

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -292,7 +292,9 @@ module Itamae
         /\A(?<repo>.+?)(?:|:(?<tag>[^:]+))\z/.match(@options[:tag]) do |m|
           image.tag(repo: m[:repo], tag: m[:tag])
         end
-        Itamae.logger.info "Image created: #{image.id}"
+        log_message = "Image created: #{image.id}"
+        log_message << ", and tagged as #{@options[:tag]}"
+        Itamae.logger.info log_message
       end
 
       private

--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -293,7 +293,7 @@ module Itamae
           image.tag(repo: m[:repo], tag: m[:tag])
         end
         log_message = "Image created: #{image.id}"
-        log_message << ", and tagged as #{@options[:tag]}"
+        log_message << ", and tagged as #{@options[:tag]}" if @options[:tag]
         Itamae.logger.info log_message
       end
 


### PR DESCRIPTION
This change will make `itamae docker` command to display tag name after the image is created if `tag` option is specified.

For example:

```
$ bundle exec itamae docker --image base-image path/to/role.rb --tag awesome-something:latest

(snip)

 INFO : Image created: sha256:24b0ede58da84ed28bafb629121d16b87e2d36cb96d8361413fdb2555876cac8, and tagged as awesome-something:latest
```

I think displaying created tag name is useful. It remind me the tag name.
And it is the same behaviour with `docker build` command.

```
$ docker build -t foo:bar .

(snip)

Successfully built 24b0ede58da8
Successfully tagged foo:bar
```