### PR TITLE
Run test cases correctly

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,7 +69,7 @@ namespace :spec do
         RSpec::Core::RakeTask.new(target.to_sym) do |t|
           ENV['DOCKER_CONTAINER'] = container_name
           t.ruby_opts = '-I ./spec/integration'
-          t.pattern = "spec/integration/[default|docker]_spec.rb"
+          t.pattern = "spec/integration/{default,docker}_spec.rb"
         end
       end
 


### PR DESCRIPTION
Since https://github.com/itamae-kitchen/itamae/pull/281 , spec for integration tests are not executed.

Because the pattern is not correct. `[default|docker]` is bad for OR pattern.
It should be `{default,docker}`.
https://relishapp.com/rspec/rspec-core/v/3-8/docs/command-line/pattern-option#the-%60--pattern%60-flag-accepts-shell-style-glob-unions


This change makes the test cases to be executed.

It was introduced by me. I'm sorry🙇🙇

Before
===

```console
$ bundle exec rake spec:integration:ubuntu:trusty

(snip)

/home/pocke/.rbenv/versions/trunk/bin/ruby -I ./spec/integration -I/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rspec-core-3.8.0/lib:/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rspec-support-3.8.0/lib /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rspec-core-3.8.0/exe/rspec --pattern spec/integration/\[default\|docker\]_spec.rb
No examples found.

Finished in 0.00016 seconds (files took 0.03293 seconds to load)
0 examples, 0 failures
```



After
===

```console
$ bundle exec rake spec:integration:ubuntu:trusty

(snip)

/home/pocke/.rbenv/versions/trunk/bin/ruby -I ./spec/integration -I/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rspec-core-3.8.0/lib:/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rspec-support-3.8.0/lib /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/rspec-core-3.8.0/exe/rspec --pattern spec/integration/\{default,docker\}_spec.rb

(snip)

Finished in 13.9 seconds (files took 0.28032 seconds to load)
139 examples, 0 failures
```