### PR TITLE
Ignore .ruby-version in this repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 .vagrant
 Gemfile.local
+.ruby-version


### PR DESCRIPTION
In the case of gem development, we use several ruby versions that switch by rbenv.

So, `.ruby-version` files change but we want to ignore this from git.