### PR TITLE
Specify required ruby version to 2.2.6 or greater

### DIFF
--- a/itamae.gemspec
+++ b/itamae.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '>= 2.2.6'
 
   spec.add_runtime_dependency "thor"
   spec.add_runtime_dependency "specinfra", [">= 2.64.0", "< 3.0.0"]


### PR DESCRIPTION
Itamae is dependent by specinfra that's version is 2.64.0 or greater currently.
Specinfra requires net-ssh gem version 2.7 or greater and net-ssh gem requires ruby version 2.2.6 or greater.
Therefore itamae requires ruby 2.2.6 or greater as practically.
This pull request does specify the required ruby version to gemspec for end-user helpful.


## supplement
My investigation article (ja_JP) :arrow_right: https://note.mu/unasuke/n/n5fe89607c517