### PR TITLE
Don't overwrite RUBY_OPT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - travis_retry gem install bundler --no-document || travis_retry gem install bundler --no-document -v 1.17.3
 
 script:
-  - bundle exec rake spec
+  - RUBYOPT=$SPEC_RUBYOPT bundle exec rake spec
 notifications:
   email: false
   slack:
@@ -28,9 +28,9 @@ matrix:
   - rvm: ruby-head
   include:
   - rvm: 2.6
-    env: RUBYOPT="--jit"
+    env: SPEC_RUBYOPT="--jit"
   - rvm: ruby-head
-    env: RUBYOPT="--jit"
+    env: SPEC_RUBYOPT="--jit"
 branches:
   only:
   - master


### PR DESCRIPTION
`ruby: invalid option --jit` error before running rspec.

So I imagine travis internal script is ruby < 2.6

https://travis-ci.org/itamae-kitchen/itamae/jobs/549025123