### PR TITLE
Add system_group option

### DIFF
--- a/itamae.gemspec
+++ b/itamae.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "serverspec", "~> 2.1"
+  spec.add_development_dependency "serverspec", "~> 2.43"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "docker-api", "~> 2"
   spec.add_development_dependency "fakefs"

--- a/itamae.gemspec
+++ b/itamae.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "thor", ">= 1.0.0"
-  spec.add_runtime_dependency "specinfra", [">= 2.64.0", "< 3.0.0"]
+  spec.add_runtime_dependency "specinfra", [">= 2.81.0", "< 3.0.0"]
   spec.add_runtime_dependency "hashie"
   spec.add_runtime_dependency "ansi"
   spec.add_runtime_dependency "schash", "~> 0.1.0"

--- a/lib/itamae/resource/group.rb
+++ b/lib/itamae/resource/group.rb
@@ -4,6 +4,7 @@ module Itamae
       define_attribute :action, default: :create
       define_attribute :groupname, type: String, default_name: true
       define_attribute :gid, type: Integer
+      define_attribute :system_group, type: [TrueClass, FalseClass]
 
       def set_current_attributes
         current.exist = exist?
@@ -21,7 +22,8 @@ module Itamae
           end
         else
           options = {
-            gid: attributes.gid,
+            gid:          attributes.gid,
+            system_group: attributes.system_group,
           }
 
           run_specinfra(:add_group, attributes.groupname, options)

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -7,6 +7,16 @@ describe user("itamae") do
   it { should have_login_shell '/bin/dash' }
 end
 
+describe user("itamae_system") do
+  it { should exist }
+  it { should be_is_system_user }
+end
+
+describe group("itamae_system") do
+  it { should exist }
+  it { should be_is_system_group }
+end
+
 describe file('/tmp/included_recipe') do
   it { should be_file }
 end

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -39,6 +39,17 @@ user "create itamae2 user with create home directory" do
   shell "/bin/sh"
 end
 
+group "create itamae_system group" do
+  groupname "itamae_system"
+  system_group true
+end
+
+user "create itamae_system user" do
+  gid "itamae_system"
+  username "itamae_system"
+  system_user true
+end
+
 ######
 
 package 'jq' do


### PR DESCRIPTION
## Summary

Add a `system_group` attribute to the `group` resource.
It is forwarded to specinfra's `add_group`, which turns it into `-r`/`--system` of `groupadd(8)`.

```ruby
group "create itamae_system group" do
  groupname "itamae_system"
  system_group true
end
```

## Motivation

The `user` resource accepts `system_user`.
The `group` resource has no counterpart, so a recipe cannot create a system group.

## Changes

- `group` resource: accept `system_group` and pass it to `add_group`.
- Bump `specinfra` from `>= 2.64.0` to `>= 2.81.0`.
  - v2.80.0 added `system_group` to `add_group` (mizzy/specinfra@216f731).
  - Older versions silently ignore it and create a regular group.
  - v2.81.0 added `check_is_system_group` / `check_is_system_user`
    (mizzy/specinfra@990dbc9), used by the integration specs.
- Bump `serverspec` from `~> 2.1` to `~> 2.43`.
  - v2.43.0 added the `is_system_group?` / `is_system_user?` matchers
    (mizzy/serverspec@0cd1cb9). They do not exist in 2.1.
- Integration tests: create an `itamae_system` group and user, with `system_group true` and `system_user true` respectively.
  - The user's primary group is the `itamae_system` group.
  - Verified with `be_is_system_group` / `be_is_system_user`.
  - `system_user` had no integration coverage before either.