### PR TITLE
Try to fix build in ruby-head

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,7 @@ namespace :spec do
             ],
           ]
           suites.each do |suite|
-            cmd = %w!bundle exec ruby -w bin/itamae docker!
+            cmd = %w!ruby -w bin/itamae docker!
             cmd << "-l" << (ENV['LOG_LEVEL'] || 'debug')
             cmd << "-j" << "spec/integration/recipes/node.json"
             cmd << "--container" << container_name


### PR DESCRIPTION
Since Ruby 2.7-dev, rubygems raises a LoadError when `bundle exec` is used.
I guess it is a bug of bundler or rubygems. 

For example: https://travis-ci.org/itamae-kitchen/itamae/jobs/567234529

```
["bundle", "exec", "ruby", "-w", "bin/itamae", "docker", "-l", "debug", "-j", "spec/integration/recipes/node.json", "--container", "itamae", "--tag", "itamae:latest", "spec/integration/recipes/default.rb", "spec/integration/recipes/default2.rb", "spec/integration/recipes/redefine.rb", "spec/integration/recipes/docker.rb"]
433Traceback (most recent call last):
434	3: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/bin/ruby_executable_hooks:24:in `<main>'
435	2: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/bin/ruby_executable_hooks:24:in `eval'
436	1: from /home/travis/.rvm/gems/ruby-head/bin/bundle:23:in `<main>'
437/home/travis/.rvm/gems/ruby-head/bin/bundle:23:in `load': cannot load such file -- /home/travis/.rvm/rubies/ruby-head/lib/bin/bundle (LoadError)
```



This patch removes `bundle exec` from Rakefile to fix the error.
It is not problematic because it keeps environment variables that are set by `bundle exec`.