### PR TITLE
Fix failing unit spec (cron 2019-10-05)

### DIFF
--- a/spec/unit/lib/itamae/backend_spec.rb
+++ b/spec/unit/lib/itamae/backend_spec.rb
@@ -18,13 +18,13 @@ module Itamae
       describe ".send_file" do
         context "the source file doesn't exist" do
           subject { -> { itamae_backend.send_file("src", "dst") } }
-          it { expect(subject).to raise_error(Itamae::Backend::SourceNotExistError, "The file 'src' doesn't exist.") }
+          it { expect{ subject }.to raise_error(Itamae::Backend::SourceNotExistError, "The file 'src' doesn't exist.") }
         end
 
         context "the source file exist, but it is not a regular file" do
           before { Dir.mkdir("src")  }
           subject { -> { itamae_backend.send_file("src", "dst") } }
-          it { expect(subject).to raise_error(Itamae::Backend::SourceNotExistError, "'src' is not a file.") }
+          it { expect{ subject }.to raise_error(Itamae::Backend::SourceNotExistError, "'src' is not a file.") }
         end
 
         context "the source file is a regular file" do
@@ -37,13 +37,13 @@ module Itamae
       describe ".send_directory" do
         context "the source directory doesn't exist" do
           subject { -> { itamae_backend.send_directory("src", "dst") } }
-          it { expect(subject).to raise_error(Itamae::Backend::SourceNotExistError, "The directory 'src' doesn't exist.") }
+          it { expect{ subject }.to raise_error(Itamae::Backend::SourceNotExistError, "The directory 'src' doesn't exist.") }
         end
 
         context "the source directory exist, but it is not a directory" do
           before { FileUtils.touch("src")  }
           subject { -> { itamae_backend.send_directory("src", "dst") } }
-          it { expect(subject).to raise_error(Itamae::Backend::SourceNotExistError, "'src' is not a directory.") }
+          it { expect{ subject }.to raise_error(Itamae::Backend::SourceNotExistError, "'src' is not a directory.") }
         end
 
         context "the source directory is a directory" do

--- a/spec/unit/lib/itamae/backend_spec.rb
+++ b/spec/unit/lib/itamae/backend_spec.rb
@@ -17,38 +17,38 @@ module Itamae
 
       describe ".send_file" do
         context "the source file doesn't exist" do
-          subject { -> { itamae_backend.send_file("src", "dst") } }
+          subject { itamae_backend.send_file("src", "dst") }
           it { expect{ subject }.to raise_error(Itamae::Backend::SourceNotExistError, "The file 'src' doesn't exist.") }
         end
 
         context "the source file exist, but it is not a regular file" do
           before { Dir.mkdir("src")  }
-          subject { -> { itamae_backend.send_file("src", "dst") } }
+          subject { itamae_backend.send_file("src", "dst") }
           it { expect{ subject }.to raise_error(Itamae::Backend::SourceNotExistError, "'src' is not a file.") }
         end
 
         context "the source file is a regular file" do
           before { FileUtils.touch("src")  }
-          subject { -> { itamae_backend.send_file("src", "dst") } }
+          subject { itamae_backend.send_file("src", "dst") }
           it { expect { subject }.not_to raise_error }
         end
       end
 
       describe ".send_directory" do
         context "the source directory doesn't exist" do
-          subject { -> { itamae_backend.send_directory("src", "dst") } }
+          subject { itamae_backend.send_directory("src", "dst") }
           it { expect{ subject }.to raise_error(Itamae::Backend::SourceNotExistError, "The directory 'src' doesn't exist.") }
         end
 
         context "the source directory exist, but it is not a directory" do
           before { FileUtils.touch("src")  }
-          subject { -> { itamae_backend.send_directory("src", "dst") } }
+          subject { itamae_backend.send_directory("src", "dst") }
           it { expect{ subject }.to raise_error(Itamae::Backend::SourceNotExistError, "'src' is not a directory.") }
         end
 
         context "the source directory is a directory" do
           before { Dir.mkdir("src")  }
-          subject { -> { itamae_backend.send_directory("src", "dst") } }
+          subject { itamae_backend.send_directory("src", "dst") }
           it { expect { subject }.not_to raise_error }
         end
       end


### PR DESCRIPTION
Fixed failing master (triggered by cron)
https://travis-ci.org/itamae-kitchen/itamae/builds/593854253

## changes
- Use block argument to `expect` in using `raise_error` matcher
    - 	https://github.com/rspec/rspec-expectations#expecting-errors
    - https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers/raise-error-matcher
- Stop wrapping subject body by lambda
    - 	It seems unnecessary.