### PR TITLE
Don't use `sudo` when `--no-sudo` is passed

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -188,12 +188,17 @@ module Itamae
         end
 
         user = options[:user]
-        if user
+        if user && use_sudo?
           command = "cd ~#{user.shellescape} ; #{command}"
           command = "sudo -H -u #{user.shellescape} -- #{shell.shellescape} -c #{command.shellescape}"
         end
 
         command
+      end
+
+      def use_sudo?
+        return true unless @options.key?(:sudo)
+        !!@options[:sudo]
       end
 
       def shell


### PR DESCRIPTION
# Context
I want to run `itamae ssh --no-sudo` as **non**-sudo user.

But itamae implicitly depends on sudo. :tired_face:
https://github.com/itamae-kitchen/itamae/blob/v1.10.5/lib/itamae/backend.rb#L190-L194

So I tried not to call `sudo` when `--no-sudo` is passed

# Example
```ruby
# cookbooks/default.rb

include_recipe "rbenv::user"
```

```bash
$ bundle exec itamae ssh --user deploy --no-sudo --node-yaml=nodes/default.yml --host xx.xx.xx.xx cookbooks/default.rb --dry-run --log-level=debug
 INFO : Starting Itamae... (dry-run)
 INFO : Loading node data from /app/nodes/default.yml...
DEBUG : Executing `mkdir -p /tmp/itamae_tmp`...
DEBUG :   exited with 0
DEBUG : Executing `chmod 777 /tmp/itamae_tmp`...
DEBUG :   exited with 0
DEBUG : stdout | Linux 3.16.0-4-amd64
DEBUG : stdout | 8.8
DEBUG : stdout | Distributor ID:Debian
DEBUG : stdout | Release:8.8
DEBUG : stdout | x86_64
 INFO : Recipe: /app/cookbooks/default.rb
 INFO :   Recipe: /app/cookbooks/rbenv/default.rb
 INFO :     Recipe: /app/vendor/bundle/ruby/2.6.0/gems/itamae-plugin-recipe-rbenv-0.6.10/lib/itamae/plugin/recipe/rbenv/user.rb
 INFO :       Recipe: /app/vendor/bundle/ruby/2.6.0/gems/itamae-plugin-recipe-rbenv-0.6.10/lib/itamae/plugin/recipe/rbenv/install.rb
DEBUG :         git[/home/deploy/.rbenv]
DEBUG :           git[/home/deploy/.rbenv] action: sync
DEBUG :             (in pre_action)
DEBUG :             (in set_current_attributes)
DEBUG :             Executing `sudo -H -u deploy -- /bin/sh -c cd\ \~deploy\ \;\ test\ -d\ /home/deploy/.rbenv`...
DEBUG :               stdout | Sorry, user deploy is not allowed to execute '/bin/sh -c cd ~deploy ; test -d /home/deploy/.rbenv' as deploy on app-staging-01.
DEBUG :               exited with 1
DEBUG :             (in show_differences)
 INFO :             git[/home/deploy/.rbenv] exist will change from 'false' to 'true'
DEBUG :             This resource is updated.
DEBUG :         directory[/home/deploy/.rbenv/plugins]
DEBUG :           directory[/home/deploy/.rbenv/plugins] action: create
DEBUG :             (in pre_action)
DEBUG :             (in set_current_attributes)
DEBUG :             Executing `sudo -H -u deploy -- /bin/sh -c cd\ \~deploy\ \;\ test\ -d\ /home/deploy/.rbenv/plugins`...
DEBUG :               stdout | Sorry, user deploy is not allowed to execute '/bin/sh -c cd ~deploy ; test -d /home/deploy/.rbenv/plugins' as deploy on app-staging-01.
DEBUG :               exited with 1
DEBUG :             (in show_differences)
 INFO :             directory[/home/deploy/.rbenv/plugins] exist will change from 'false' to 'true'
DEBUG :             This resource is updated.
DEBUG :         rbenv_plugin[ruby-build]
DEBUG :           git[/home/deploy/.rbenv/plugins/ruby-build]
DEBUG :             git[/home/deploy/.rbenv/plugins/ruby-build] action: sync
DEBUG :               (in pre_action)
DEBUG :               (in set_current_attributes)
DEBUG :               Executing `sudo -H -u deploy -- /bin/sh -c cd\ \~deploy\ \;\ test\ -d\ /home/deploy/.rbenv/plugins/ruby-build`...
DEBUG :                 stdout | Sorry, user deploy is not allowed to execute '/bin/sh -c cd ~deploy ; test -d /home/deploy/.rbenv/plugins/ruby-build' as deploy on app-staging-01.
DEBUG :                 exited with 1
DEBUG :               (in show_differences)
 INFO :               git[/home/deploy/.rbenv/plugins/ruby-build] exist will change from 'false' to 'true'
DEBUG :               This resource is updated.
DEBUG :         execute[rbenv install 2.6.4]
DEBUG :           Executing `sudo -H -u deploy -- /bin/sh -c cd\ \~deploy\ \;\ \ \ export\ RBENV_ROOT\=/home/deploy/.rbenv'
'\ \ export\ PATH\=\"/home/deploy/.rbenv/bin:\$\{PATH\}\"'
'\ \ eval\ \"\$\(rbenv\ init\ --no-rehash\ -\)\"'
'\ rbenv\ versions\ --bare\ \|\ grep\ -x\ 2.6.4`...
DEBUG :             stdout | Sorry, user deploy is not allowed to execute '/bin/sh -c cd ~deploy ;   export RBENV_ROOT=/home/deploy/.rbenv
DEBUG :             stdout |   export PATH="/home/deploy/.rbenv/bin:${PATH}"
DEBUG :             stdout |   eval "$(rbenv init --no-rehash -)"
DEBUG :             stdout |  rbenv versions --bare | grep -x 2.6.4' as deploy on app-staging-01.
DEBUG :             exited with 1
DEBUG :           execute[rbenv install 2.6.4] action: run
DEBUG :             (in pre_action)
DEBUG :             (in set_current_attributes)
DEBUG :             (in show_differences)
 INFO :             execute[rbenv install 2.6.4] executed will change from 'false' to 'true'
DEBUG :             This resource is updated.
```
