### PR TITLE
Use 2.7-rc until ruby:2.7 is pushed

### DIFF
--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -57,13 +57,16 @@ namespace 'spec:integration:local' do
 end
 
 class IntegrationLocalSpecRunner
+  RUBY_VERSION_ALIAS = {
+    '2.7' => '2.7-rc', # workaround until ruby:2.7 is pushed
+  }
   CONTAINER_NAME = 'itamae'
   include FileUtils
 
   def initialize(suites, specs, ruby_version: RUBY_VERSION.split('.')[0..1].join('.'), user: nil)
     @suites = suites
     @specs = specs
-    @ruby_version = ruby_version
+    @ruby_version = RUBY_VERSION_ALIAS.fetch(ruby_version, ruby_version)
     @user = user
 
     docker_run


### PR DESCRIPTION
Follows up https://github.com/itamae-kitchen/itamae/commit/9d9d3f8c92523e9d62dd35e39900c0d3a04e1756