### PR TITLE
Fix to set "verify_host_key" based on "strict_host_key_checking" value

### DIFF
--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -261,6 +261,8 @@ module Itamae
         opts[:password] = @options[:password] if @options[:password]
         opts[:keys] = [@options[:key]] if @options[:key]
         opts[:port] = @options[:port] if @options[:port]
+        opts[:verify_host_key] = :never if opts[:strict_host_key_checking] == false
+        opts.delete(:strict_host_key_checking)
 
         if @options[:vagrant]
           config = Tempfile.new('', Dir.tmpdir)

--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -261,8 +261,6 @@ module Itamae
         opts[:password] = @options[:password] if @options[:password]
         opts[:keys] = [@options[:key]] if @options[:key]
         opts[:port] = @options[:port] if @options[:port]
-        opts[:verify_host_key] = :never if opts[:strict_host_key_checking] == false
-        opts.delete(:strict_host_key_checking)
 
         if @options[:vagrant]
           config = Tempfile.new('', Dir.tmpdir)
@@ -284,6 +282,9 @@ module Itamae
           print "\n"
           opts.merge!(password: password)
         end
+
+        opts[:verify_host_key] = :never if opts[:strict_host_key_checking] == false
+        opts.delete(:strict_host_key_checking)
 
         opts
       end

--- a/spec/unit/lib/itamae/backend_spec.rb
+++ b/spec/unit/lib/itamae/backend_spec.rb
@@ -82,6 +82,7 @@ Host ex1
   HostName example.com
   User myname
   Port 10022
+  StrictHostKeyChecking no
 EOF
               temp.flush
               @ssh_config = temp.path
@@ -91,7 +92,7 @@ EOF
 
           let(:options) { {host: "ex1", ssh_config: @ssh_config} }
 
-          it { is_expected.to a_hash_including({host_name: "example.com", user: "myname", port: 10022}) }
+          it { is_expected.to a_hash_including({host_name: "example.com", user: "myname", port: 10022, verify_host_key: :never}) }
         end
       end
 


### PR DESCRIPTION
**summary**
This PR fixes to set `verify_host_key` based on `StrictHostKeyChecking` configuration.

## Context

I tried to test provisioning with vagrant, however, I got an error below.

```
 ❯ bundle exec itamae ssh --host vagrant-ubuntu -y nodes/main.yml entrypoint.rb                                                                                                                                                                                  [17:02:12]
 INFO : Starting Itamae...
 INFO : Loading node data from /Users/hoge/itamae-workspace/nodes/main.yml...
bundler: failed to load command: itamae (/Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/bin/itamae)
ArgumentError: invalid option(s): strict_host_key_checking
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/net-ssh-6.0.2/lib/net/ssh.rb:221:in `start'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/specinfra-2.82.15/lib/specinfra/backend/ssh.rb:76:in `create_ssh'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/specinfra-2.82.15/lib/specinfra/backend/ssh.rb:110:in `ssh_exec!'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/specinfra-2.82.15/lib/specinfra/backend/ssh.rb:17:in `block in run_command'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/specinfra-2.82.15/lib/specinfra/backend/ssh.rb:67:in `with_env'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/specinfra-2.82.15/lib/specinfra/backend/ssh.rb:16:in `run_command'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/itamae-1.10.7/lib/itamae/backend.rb:210:in `run_command_with_profiling'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/itamae-1.10.7/lib/itamae/backend.rb:57:in `block in run_command'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/itamae-1.10.7/lib/itamae/logger.rb:9:in `with_indent'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/itamae-1.10.7/lib/itamae/backend.rb:54:in `run_command'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/itamae-1.10.7/lib/itamae/runner.rb:37:in `initialize'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/itamae-1.10.7/lib/itamae/runner.rb:11:in `new'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/itamae-1.10.7/lib/itamae/runner.rb:11:in `run'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/itamae-1.10.7/lib/itamae/cli.rb:137:in `run'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/itamae-1.10.7/lib/itamae/cli.rb:59:in `ssh'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/gems/itamae-1.10.7/bin/itamae:4:in `<top (required)>'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/bin/itamae:23:in `load'
  /Users/hoge/itamae-workspace/vendor/bundle/ruby/2.7.0/bin/itamae:23:in `<top (required)>'
```

This might be a net-ssh issue. The output of `vagrant ssh-config <vm_name>` contains `StrictHostKeyChecking` configuration. It is mapped to ":strict_host_key_checking", but `SSH.start`doesn't accept it as an valid option. This flag was added for supplying information to users about how to configure `verify_host_key` option. Thus this option shouldn't be passed directly to `Net::SSH.start`. [ref](https://github.com/net-ssh/net-ssh/commit/50b77572207a5bcef801fd1b50be240f7c80eb2f)

FYI:
- https://github.com/net-ssh/net-ssh/blob/master/lib/net/ssh/config.rb 
- https://github.com/net-ssh/net-ssh/blob/139126b08ded6fe2451c3791a1c041f378920a05/lib/net/ssh.rb#L66-L78

I think this option should not be passed directly, and instead `verify_host_key` should be passed based on `strict_host_key_checking` value.

my working environment is here.
- macOS 10.15.3
- Ruby 2.7.1
- itamae v1.10.7
