### PR TITLE
Simplify Git resource's get_revision method

### DIFF
--- a/lib/itamae/resource/git.rb
+++ b/lib/itamae/resource/git.rb
@@ -88,7 +88,7 @@ module Itamae
         return result.stdout.strip if result.exit_status == 0
 
         fetch_origin!
-        run_command_in_repo("git rev-parse #{shell_escape(branch)}").strip
+        run_command_in_repo("git rev-parse #{shell_escape(branch)}").stdout.strip
       end
 
       def fetch_origin!

--- a/lib/itamae/resource/git.rb
+++ b/lib/itamae/resource/git.rb
@@ -84,11 +84,11 @@ module Itamae
       end
 
       def get_revision(branch)
-        result = run_command_in_repo("git rev-list #{shell_escape(branch)}", error: false)
-        unless result.exit_status == 0
-          fetch_origin!
-        end
-        run_command_in_repo("git rev-list #{shell_escape(branch)}").stdout.lines.first.strip
+        result = run_command_in_repo("git rev-parse #{shell_escape(branch)}", error: false)
+        return result.stdout.strip if result.exit_status == 0
+
+        fetch_origin!
+        run_command_in_repo("git rev-parse #{shell_escape(branch)}").strip
       end
 
       def fetch_origin!


### PR DESCRIPTION
This pull request simplifies `get_revision` method of `Itamae::Resource::Git`.
It will improve performance.


This pull request contains two changes.

First, it replaces `git rev-list` with `git rev-parse`.
`git rev-parse` is faster, and enough. `rev-list` prints all revisions in the specified branch, but `rev-parse` only prints the head revision.


It is a really simple benchmark.

```ruby
require 'benchmark'
Benchmark.bm do |x|
  x.report{100.times{`git rev-parse @`}}
  x.report{100.times{`git rev-list @`}}
end

# In itamae repository
#
#        user     system      total        real
#    0.012472   0.020599   0.245997 (  0.235425)
#    0.124308   0.398403   2.054095 (  1.553693)
```



Second, it reduces git command executions when `git fetch` is unnecessary.



---


I guess this pull request only has a small impact on performance because `git` resource always try fetching new commits from the remote repository by default.