### PR TITLE
Reduce `check_package_is_installed` calling when package version is not specified

### DIFF
--- a/lib/itamae/resource/package.rb
+++ b/lib/itamae/resource/package.rb
@@ -24,6 +24,8 @@ module Itamae
       end
 
       def action_install(action_options)
+        return if !attributes.version && current.installed
+
         unless run_specinfra(:check_package_is_installed, attributes.name, attributes.version)
           run_specinfra(:install_package, attributes.name, attributes.version, attributes.options)
           updated!
@@ -31,7 +33,7 @@ module Itamae
       end
 
       def action_remove(action_options)
-        if run_specinfra(:check_package_is_installed, attributes.name, nil)
+        if current.installed
           run_specinfra(:remove_package, attributes.name, attributes.options)
           updated!
         end


### PR DESCRIPTION
`package` resource executes an unnecessary command to check package existence when the package version is not specified. So this pull request removes the command execution.




Currently, it always calls `check_package_is_installed` in `Itamae::Resource::Package#action_install`.
But it is redundant if the `version` attribute is not specified.
Because it has been called without version in the `current_attributes` method, and the result is stored in `current.installed`.


So if the `attributes.version` is nil, `run_specinfra(:check_package_is_installed, attributes.name, attributes.version)` and `current.installed` are exactly the same. It is omittable.




I think this change is reasonable because the `package` resource is one of the most used resources, and the `version` attribute is omitted in many cases.
So this change has the potential to reduce execution time.


## Bencmark

```ruby
# for arch linux
# all packages have been installed.
%w[vim tmux libffi libyaml openssl zlib git].each do |pkg|
  package pkg do
    user 'root'
  end
end
```

I applied [the above itamae script](https://github.com/pocke/infra2/blob/95690be1c77a21a13703daa73f191a7bcbb1f6b8/roles/raspberry-pi-4.rb#L55-L59) to my raspberry pi via SSH five times, and got the following result (1.3x faster).

* before: 24.82s
* after: 18.94s

