### PR TITLE
Print "(in action_XXX)" as a debug log

### DIFF
--- a/lib/itamae/resource/base.rb
+++ b/lib/itamae/resource/base.rb
@@ -195,6 +195,7 @@ module Itamae
             show_differences
 
             method_name = "action_#{action}"
+            Itamae.logger.debug "(in #{method_name})"
             if runner.dry_run?
               unless respond_to?(method_name)
                 Itamae.logger.error "action #{action.inspect} is unavailable"


### PR DESCRIPTION
# Problem


With `--log-level=debug`, the logger prints execution phase, such as "(in pre_action)", "in show_differences".
But it does not print the `action_XXX` phases. So it is confusing. 

For example

```ruby
package 'vim' do
  user 'root'
end
```

With the above recipe, the debug logger prints the following.

```
DEBUG :       Executing `sudo -H -u root -- /bin/sh -c cd\ \~root\ \;\ pacman\ -Q\ vim\ \|\|\ pacman\ -Qg\ vim`...
DEBUG :         stdout | vim 8.2.0510-2
DEBUG :         exited with 0
DEBUG :       Executing `sudo -H -u root -- /bin/sh -c cd\ \~root\ \;\ pacman\ -Qi\ vim\ \|\ grep\ Version\ \|\ awk\ \'\{print\ \$3\}\'`...
DEBUG :         stdout | 8.2.0510-2
DEBUG :         exited with 0
DEBUG :       (in show_differences)
DEBUG :       package[vim] installed will not change (current value is 'true')
DEBUG :       package[vim] version will not change (current value is '8.2.0510-2')
DEBUG :       Executing `sudo -H -u root -- /bin/sh -c cd\ \~root\ \;\ pacman\ -Q\ vim\ \|\|\ pacman\ -Qg\ vim`...
DEBUG :         stdout | vim 8.2.0510-2
DEBUG :         exited with 0
```

The last three lines are in show_differences phase in the log, but actually the command was executed in `action_install` method.

# Solution


Add "(in action_XXX)" logging before calling `action_XXX`.

The log will be the following.

```
DEBUG :       Executing `sudo -H -u root -- /bin/sh -c cd\ \~root\ \;\ pacman\ -Q\ vim\ \|\|\ pacman\ -Qg\ vim`...
DEBUG :         stdout | vim 8.2.0510-2
DEBUG :         exited with 0
DEBUG :       Executing `sudo -H -u root -- /bin/sh -c cd\ \~root\ \;\ pacman\ -Qi\ vim\ \|\ grep\ Version\ \|\ awk\ \'\{print\ \$3\}\'`...
DEBUG :         stdout | 8.2.0510-2
DEBUG :         exited with 0
DEBUG :       (in show_differences)
DEBUG :       package[vim] installed will not change (current value is 'true')
DEBUG :       package[vim] version will not change (current value is '8.2.0510-2')
DEBUG :       (in action_install)
DEBUG :       Executing `sudo -H -u root -- /bin/sh -c cd\ \~root\ \;\ pacman\ -Q\ vim\ \|\|\ pacman\ -Qg\ vim`...
DEBUG :         stdout | vim 8.2.0510-2
DEBUG :         exited with 0
```