### PR TITLE
Fix CRLF problem in windows

### DIFF
--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -195,7 +195,7 @@ module Itamae
                 else
                   f = 
                     if Gem.win_platform?
-                      Tempfile.open('itamae', :mode=>IO::RDWR | IO::CREAT | IO::TRUNC | IO::BINARY)
+                      Tempfile.open('itamae', :mode=>IO::BINARY)
                     else
                       Tempfile.open('itamae')
                     end

--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -193,7 +193,12 @@ module Itamae
           src = if content_file
                   content_file
                 else
-                  f = Tempfile.open('itamae', :mode=>IO::RDWR | IO::CREAT | IO::TRUNC | IO::BINARY)
+                  f = 
+                    if Gem.win_platform?
+                      Tempfile.open('itamae', :mode=>IO::RDWR | IO::CREAT | IO::TRUNC | IO::BINARY)
+                    else
+                      Tempfile.open('itamae')
+                    end
                   f.write(attributes.content)
                   f.close
                   f.path


### PR DESCRIPTION
This pull request is based on #236.
I added check of platform before expressly specifying file open mode.

The problem changed a little since then.

## Platform

All symptoms below occur **only** when executing `itamae ssh` in **Windows platform**.

## Cause

`Tempfile`'s default open mode is `w+`, which convert `LF` into `CR LF` in Windows platform.
The mode should be expressly specified as `w+b` or `IO::RDWR | IO::CREAT | IO::TRUNC | IO::BINARY` to prevent this behavior.
cf. ) https://github.com/ruby/ruby/blob/master/lib/tempfile.rb#L81

## Symptom 1

This `Tempfile` is only used when file `content_file` attribute is nil, which means that affects only `file` resource and `template` resource in `itamae ssh`.

* `file` resource with `content` attribute changes all `LF` into `CR LF` in content.
* `template` resource changes all `LF` into `CR LF` in template.

## Symptom 2

Since #310 merged:

* With `file` and `template` resource, differences of file format is not detected.

This comes from check strategy below:

(1) File hash is calculated from string which is still in UNIX file format.
(2) `diff -q ` is executed against the temporary file which is in DOS file format.

### Example

Recipe:

```ruby
file "test file" do
  path "/tmp/file_test.sh"
  content <<~EOF
    #!/bin/bash
    echo "hogehoge"
  EOF
  mode "0755"
end
```

`/tmp/file_test.sh` in provisioned host:

```sh
#!/bin/bash
echo "hgoehoge"
```

When `/tmp/file_test.sh` is in UNIX format, it passes check (1).

```
DEBUG :       Executing `sha256sum /tmp/file_test.sh`...
DEBUG :         stdout | 78899405e3efe041d8a44c95823a3f53aa4df0b3422e7e70859fb996364a81ac  /tmp/file_test.sh
DEBUG :         exited with 0
DEBUG :       (in set_current_attributes)
DEBUG :       Executing `stat -c %a /tmp/file_test.sh`...
DEBUG :         stdout | 755
DEBUG :         exited with 0
DEBUG :       Executing `stat -c %U /tmp/file_test.sh`...
DEBUG :         stdout | vagrant
DEBUG :         exited with 0
DEBUG :       Executing `stat -c %G /tmp/file_test.sh`...
DEBUG :         stdout | vagrant
DEBUG :         exited with 0
DEBUG :       (in show_differences)
DEBUG :       file[test file] exist will not change (current value is 'true')
DEBUG :       file[test file] modified will not change (current value is 'false')
DEBUG :       file[test file] mode will not change (current value is '0755')
DEBUG :       file[test file] owner will not change (current value is 'vagrant')
DEBUG :       file[test file] group will not change (current value is 'vagrant')
DEBUG :       (in action_create)
DEBUG :       Executing `chmod 0755 /tmp/file_test.sh`...
DEBUG :         exited with 0
```

When `/tmp/file_test.sh` is in DOS format, it fails check (1) but passes check (2).

 ```
DEBUG :       Executing `sha256sum /tmp/file_test.sh`...
DEBUG :         stdout | 68165e1bc0b8caf06e5aaeadcbb2cdb121adcda054e5b4f85d5e3dcbab31b894  /tmp/file_test.sh
DEBUG :         exited with 0
DEBUG :       Executing `touch /tmp/itamae_tmp/1589709556.2647982`...
DEBUG :         exited with 0
DEBUG :       Executing `chmod 0600 /tmp/itamae_tmp/1589709556.2647982`...
DEBUG :         exited with 0
DEBUG :       Sending a file from 'C:/Users/tomot/AppData/Local/Temp/itamae20200517-19684-1rsjwg6' to '/tmp/itamae_tmp/1589709556.2647982'...
DEBUG :       Executing `chmod 0600 /tmp/itamae_tmp/1589709556.2647982`...
DEBUG :         exited with 0
DEBUG :       Executing `diff -q /tmp/file_test.sh /tmp/itamae_tmp/1589709556.2647982`...
DEBUG :         exited with 0
DEBUG :       (in set_current_attributes)
DEBUG :       Executing `stat -c %a /tmp/file_test.sh`...
DEBUG :         stdout | 755
DEBUG :         exited with 0
DEBUG :       Executing `stat -c %U /tmp/file_test.sh`...
DEBUG :         stdout | vagrant
DEBUG :         exited with 0
DEBUG :       Executing `stat -c %G /tmp/file_test.sh`...
DEBUG :         stdout | vagrant
DEBUG :         exited with 0
DEBUG :       (in show_differences)
DEBUG :       file[test file] exist will not change (current value is 'true')
DEBUG :       file[test file] modified will not change (current value is 'false')
DEBUG :       file[test file] mode will not change (current value is '0755')
DEBUG :       file[test file] owner will not change (current value is 'vagrant')
DEBUG :       file[test file] group will not change (current value is 'vagrant')
DEBUG :       file content will not change
DEBUG :       (in action_create)
DEBUG :       Executing `chmod 0755 /tmp/file_test.sh`...
DEBUG :         exited with 0
```