### PR TITLE
Make output unbuffered

### DIFF
--- a/lib/itamae/logger.rb
+++ b/lib/itamae/logger.rb
@@ -126,6 +126,7 @@ module Itamae
   @logger = ::Logger.new($stdout).tap do |l|
     l.formatter = Itamae::Logger::Formatter.new
   end.extend(Itamae::Logger::Helper)
+  $stdout.sync = true
 
   class << self
     def logger


### PR DESCRIPTION
This makes it possible to pipe the output of itamae to other tool and
have the output as it happens. Otherwise, the output is buffered and is
only available after itamae finishes.