### PR TITLE
Temporarily disable failing test

### DIFF
--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -104,7 +104,7 @@ describe file('/tmp/http_request_headers.html') do
   its(:content) { should match(/"User-Agent":\s*"Itamae"/) }
 end
 
-describe file('/tmp/http_request_redirect.html') do
+xdescribe file('/tmp/http_request_redirect.html') do
   it { should be_file }
   its(:content) { should match(/"from":\s*"itamae"/) }
 end

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -210,10 +210,10 @@ http_request "/tmp/http_request_headers.html" do
   url "https://httpbin.org/get"
 end
 
-http_request "/tmp/http_request_redirect.html" do
-  redirect_limit 1
-  url "https://httpbin.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fget%3Ffrom%3Ditamae"
-end
+# http_request "/tmp/http_request_redirect.html" do
+#   redirect_limit 1
+#   url "https://httpbin.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fget%3Ffrom%3Ditamae"
+# end
 
 link "/tmp-link" do
   to "/tmp"


### PR DESCRIPTION
Weekly build is failing since https://travis-ci.org/github/itamae-kitchen/itamae/builds/700342208

https://httpbin.org/#/Redirects/get_redirect_to says `https://httpbin.org/redirect-to` returns 302, but actual is 404

```
$ curl -I https://httpbin.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fget
HTTP/2 404
server: awselb/2.0
date: Mon, 29 Jun 2020 15:43:42 GMT
content-type: text/plain; charset=utf-8
content-length: 0
```

This is issue of https://httpbin.org

c.f. https://github.com/postmanlabs/httpbin/issues/617

So I temporarily disabled