### PR TITLE
Fix the lack of local import

### DIFF
--- a/lib/itamae/node.rb
+++ b/lib/itamae/node.rb
@@ -1,6 +1,7 @@
 require 'hashie'
 require 'json'
 require 'schash'
+require 'itamae/mash'
 
 module Itamae
   class Node


### PR DESCRIPTION
Without this line, we cannot directly use `require 'itamae/node'` to test recipes.