### PR TITLE
"itamae list" command to list itamae plugin recipes

### DIFF
--- a/lib/itamae.rb
+++ b/lib/itamae.rb
@@ -13,6 +13,7 @@ require "itamae/definition"
 require "itamae/ext"
 require "itamae/generators"
 require "itamae/mash"
+require "itamae/list"
 
 module Itamae
   # Your code goes here...

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -116,6 +116,11 @@ module Itamae
       generator.remove_files
     end
 
+    desc 'list', 'list plugin recipes'
+    def list
+      Itamae::List.new.run
+    end
+
     private
     def options
       @itamae_options ||= super.dup.tap do |options|

--- a/lib/itamae/list.rb
+++ b/lib/itamae/list.rb
@@ -1,0 +1,69 @@
+module Itamae
+  class List
+    def run
+      require 'rubygems'
+      require 'rubygems/exceptions'
+      require 'pathname'
+
+      pattern = /^itamae-plugin-recipe/
+      # from rubygems Gem::Commands::QueryCommand#show_local_gems
+      specs = Gem::Specification.find_all do |s|
+        s.name =~ pattern
+      end
+
+      req = Gem::Requirement.default
+      dep = Gem::Deprecate.skip_during { Gem::Dependency.new pattern, req }
+      specs.select! do |s|
+        dep.match?(s.name, s.version, false)
+      end
+      spec_tuples = specs.map do |spec|
+        [spec.name_tuple, spec]
+      end
+
+      # from rubygems Gem::Commands::QueryCommand#output_query_results
+      versions = Hash.new { |h,name| h[name] = [] }
+      spec_tuples.each do |spec_tuple, source|
+        versions[spec_tuple.name] << [spec_tuple, source]
+      end
+      versions = versions.sort_by do |(n,_),_|
+        n.downcase
+      end
+
+      # from rubygems Gem::Commands::QueryCommand#output_versions
+      versions.each do |gem_name, matching_tuples|
+        matching_tuples = matching_tuples.sort_by { |n,_| n.version }.reverse
+        platforms = Hash.new { |h,version| h[version] = [] }
+        matching_tuples.each do |n, _|
+          platforms[n.version] << n.platform if n.platform
+        end
+        seen = {}
+        matching_tuples.delete_if do |n,_|
+          if seen[n.version]
+            true
+          else
+            seen[n.version] = true
+            false
+          end
+        end
+        scan_lib(matching_tuples[0][1].name, matching_tuples[0][1].gem_dir)
+      end
+    end
+
+    private
+
+    def scan_lib(name, dir)
+      puts name + ' gem:'
+      Dir.glob(dir + '/lib/itamae/plugin/recipe/**/*.rb') do |f|
+        puts '  ' + to_recipe_name(f, dir)
+      end
+    end
+
+    def to_recipe_name(path, dir)
+      pn = Pathname.new(path)
+      relative_path = pn.relative_path_from(Pathname.new(dir + '/lib/itamae/plugin/recipe')).to_s
+      relative_path.gsub(/\.rb$/, '').
+          gsub('/', '::').
+          gsub(/::default$/, '')
+    end
+  end
+end


### PR DESCRIPTION
### NAME
"itamae list" command lists recipes in installed itamae-plugin-recipe-X gems

### SYNOPSIS
itamae list

### DESCRIPTION
"itamae list" command lists recipes in installed itamae-plugin-recipe-X gems; for example:

```
$ itamae list
itamae-plugin-recipe-god gem:
  god
  god::install
  god::start
  god::stop
  god::version
itamae-plugin-recipe-hadoop gem:
  hadoop
  hadoop::install
  hadoop::version
itamae-plugin-recipe-passenger gem:
  passenger
  passenger::install
  passenger::version
itamae-plugin-recipe-postgresql gem:
  postgresql
  postgresql::version
```

#### Implementation Note

The basic idea is "gem list ^itamae-plugin-recipe", scan '*.rb' , then print the path with conversion of directory separator from '/' to '::'.  "X/default.rb" will be converted to "X" as well.