### PR TITLE
Support Ruby 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
   - ruby-head
 bundler_args: "--jobs=4 --retry=3"
 cache:
@@ -30,6 +31,8 @@ matrix:
   - rvm: 2.6
     env: SPEC_RUBYOPT="--jit"
   - rvm: 2.7
+    env: SPEC_RUBYOPT="--jit"
+  - rvm: 3.0
     env: SPEC_RUBYOPT="--jit"
   - rvm: ruby-head
     env: SPEC_RUBYOPT="--jit"

--- a/itamae.gemspec
+++ b/itamae.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "serverspec", "~> 2.1"
   spec.add_development_dependency "pry-byebug"
-  spec.add_development_dependency "docker-api", "~> 1.20"
+  spec.add_development_dependency "docker-api", "~> 2"
   spec.add_development_dependency "fakefs"
   spec.add_development_dependency "fluent-logger"
 end


### PR DESCRIPTION
- add ruby 3 to travis matrix
- update docker-api gem (old docker-api uses outdated ruby api)