### PR TITLE
file: improve diff output

### DIFF
--- a/lib/itamae/resource/file.rb
+++ b/lib/itamae/resource/file.rb
@@ -164,7 +164,7 @@ module Itamae
 
         if attributes.modified
           Itamae.logger.info "diff:"
-          diff = run_command(["diff", "-u", compare_to, @temppath], error: false)
+          diff = run_command(["diff", "-u", "--label=#{attributes.path} (BEFORE)", compare_to, "--label=#{attributes.path} (AFTER)", @temppath], error: false)
           diff.stdout.each_line do |line|
             color = if line.start_with?('+')
                       :green


### PR DESCRIPTION
diff This makes the output of a changed file look like this:

INFO :   file[/path/to/file] modified will change from 'false' to 'true'
INFO :   diff:
INFO :   --- /path/to/file (BEFORE)
INFO :   +++ /path/to/file (AFTER)
INFO :   @@ -1,2 +1,2 @@
INFO :   -line 0
INFO :    line 1
INFO :   +line 2

That's a lot better than displaying a random temporary filename as the
second file.