### PR TITLE
specify thor version to "< 1.1.0"

### DIFF
--- a/itamae.gemspec
+++ b/itamae.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "thor"
+  spec.add_runtime_dependency "thor", "< 1.1.0"
   spec.add_runtime_dependency "specinfra", [">= 2.64.0", "< 3.0.0"]
   spec.add_runtime_dependency "hashie"
   spec.add_runtime_dependency "ansi"


### PR DESCRIPTION
## About
It no longer works with [thor v.1.1.0](https://rubygems.org/gems/thor/versions/1.1.0) (now latest version is 1.1.0).
So I specified smaller version.
I have tested it in [this github action](https://github.com/iyuuya/itamae-thor-test/actions/runs/524210196).

## Error
<details>
<summary>bundle exec itamae</summary>

```
$ bundle exec itamae
bundler: failed to load command: itamae (/opt/hostedtoolcache/Ruby/2.6.6/x64/bin/itamae)
/opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor/shell/basic.rb:393:in `quiet?': private method `options' called for #<Itamae::CLI:0x00005614ddcec8e8> (NoMethodError)
Did you mean?  options=
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor/shell/basic.rb:97:in `say'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor.rb:205:in `help'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor.rb:513:in `help'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor/base.rb:485:in `start'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/itamae-1.11.1/bin/itamae:4:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/bin/itamae:23:in `load'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/bin/itamae:23:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/lib/bundler/cli/exec.rb:63:in `load'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/lib/bundler/cli/exec.rb:63:in `kernel_load'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/lib/bundler/cli/exec.rb:28:in `run'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/lib/bundler/cli.rb:494:in `exec'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/lib/bundler/cli.rb:30:in `dispatch'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/lib/bundler/cli.rb:24:in `start'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/exe/bundle:49:in `block in <top (required)>'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/gems/2.6.0/gems/bundler-2.2.7/exe/bundle:37:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/bin/bundle:23:in `load'
	from /opt/hostedtoolcache/Ruby/2.6.6/x64/bin/bundle:23:in `<main>'
```
</details>


----

P.S.
根本解決のPRでなくすみません 🙇 