### PR TITLE
Support thor-1.1.0

### DIFF
--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -27,6 +27,14 @@ module Itamae
       option :config, type: :string, aliases: ['-c']
     end
 
+    def self.options
+      @itamae_options ||= super.dup.tap do |options|
+        if config = options[:config]
+          options.merge!(YAML.load_file(config))
+        end
+      end
+    end
+
     desc "local RECIPE [RECIPE...]", "Run Itamae locally"
     define_exec_options
     def local(*recipe_files)
@@ -117,14 +125,6 @@ module Itamae
     end
 
     private
-    def options
-      @itamae_options ||= super.dup.tap do |options|
-        if config = options[:config]
-          options.merge!(YAML.load_file(config))
-        end
-      end
-    end
-
     def validate_generate_target!(command, target)
       unless GENERATE_TARGETS.include?(target)
         msg = %Q!ERROR: "itamae #{command}" was called with "#{target}" !


### PR DESCRIPTION
Fixed the following errors

```
$ itamae
/home/takafumi/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor/shell/basic.rb:393:in `quiet?': private method `options' called for #<Itamae::CLI:0x00000000018cf158 @_invocations={Itamae::CLI=>["help"]}, @_initializer=[[], [], {:shell=>#<Thor::Shell::Color:0x00000000018cf608 @base=#<Itamae::CLI:0x00000000018cf158 ...>, @mute=false, @padding=0, @always_force=false>, :current_command=>#<struct Thor::Command name="help", description="Describe available commands or one specific command", long_description=nil, usage="help [COMMAND]", options={}, ancestor_name=nil>}], @options={}, @args=[], @shell=#<Thor::Shell::Color:0x00000000018cf608 @base=#<Itamae::CLI:0x00000000018cf158 ...>, @mute=false, @padding=0, @always_force=false>, @itamae_options={}> (NoMethodError)
Did you mean?  options=
	from /home/takafumi/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor/shell/basic.rb:97:in `say'
	from /home/takafumi/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor.rb:205:in `help'
	from /home/takafumi/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor.rb:513:in `help'
	from /home/takafumi/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
	from /home/takafumi/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/takafumi/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
	from /home/takafumi/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor/base.rb:485:in `start'
	from /home/takafumi/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/itamae-1.11.1/bin/itamae:4:in `<top (required)>'
	from /home/takafumi/.rbenv/versions/3.0.0/bin/itamae:23:in `load'
	from /home/takafumi/.rbenv/versions/3.0.0/bin/itamae:23:in `<main>'

```