### PR TITLE
Add --tmp-dir to cli options

### DIFF
--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -25,6 +25,7 @@ module Itamae
       option :log_level, type: :string, aliases: ['-l'], default: 'info'
       option :color, type: :boolean, default: true
       option :config, type: :string, aliases: ['-c']
+      option :tmp_dir, type: :string, aliases: ['-t'], default: "/tmp/itamae_tmp"
     end
 
     def self.options

--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -30,7 +30,7 @@ module Itamae
       prepare_handler
 
       @node = create_node
-      @tmpdir = "/tmp/itamae_tmp"
+      @tmpdir = options[:tmp_dir]
       @children = RecipeChildren.new
       @diff = false
 


### PR DESCRIPTION
I add `--tmp-dir` option to cli for #330

Usage

```bash
$ itamae ssh --no-sudo -h my-server --tmp-dir /home/sue445/itamae-tmp recipe.rb
```

Fixes #330
