### PR TITLE
package: add :upgrade action

### DIFF
--- a/lib/itamae/resource/package.rb
+++ b/lib/itamae/resource/package.rb
@@ -32,6 +32,16 @@ module Itamae
         end
       end
 
+      def action_upgrade(action_options)
+        run_specinfra(:install_package, attributes.name, attributes.version, attributes.options)
+        attributes.version = run_specinfra(:get_package_version, attributes.name).stdout.strip
+        attributes.installed = run_specinfra(:check_package_is_installed, attributes.name)
+        if !current.installed || attributes.version != current.version
+          show_differences
+          updated!
+        end
+      end
+
       def action_remove(action_options)
         if current.installed
           run_specinfra(:remove_package, attributes.name, attributes.options)


### PR DESCRIPTION
Since there is no generic way of checking whether there is a new version
of a given package, the upgrade action just installs the package
unconditionally, assuming that the package installation command will
install a newer version if it's available (that's the case for e.g.
apt-get).

Since it's only possible to check whether there was any version change
_after_ the action, show_differences needs to be called explicitly when
the package version changes for us to get some feedback in the logs.