### PR TITLE
Fix Chef install script URL

### DIFF
--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -98,7 +98,7 @@ module Itamae
         unless @backend.run_command("which ohai", error: false).exit_status == 0
           # install Ohai
           Itamae.logger.info "Installing Chef package... (to use Ohai)"
-          @backend.run_command("curl -L https://www.opscode.com/chef/install.sh | bash")
+          @backend.run_command("curl -L https://omnitruck.chef.io/install.sh | bash")
         end
 
         Itamae.logger.info "Loading node data via ohai..."


### PR DESCRIPTION
This is a change to fix a problem where the ohai option was not working because the URL for the Chef installation had changed.