### PR TITLE
Initialize tmp_dir if no tmpdir option was specified.

### DIFF
--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -30,7 +30,7 @@ module Itamae
       prepare_handler
 
       @node = create_node
-      @tmpdir = options[:tmp_dir]
+      @tmpdir = options[:tmp_dir] || '/tmp/itamae_tmp'
       @children = RecipeChildren.new
       @diff = false
 


### PR DESCRIPTION
If no tmpdir is specified you will get this error

````
/home/nedim/.rvm/gems/ruby-3.0.2/gems/itamae-1.12.3/lib/itamae/backend.rb:183:in `block in build_command': undefined method `shellescape' for nil:NilClass (NoMethodError)
	from /home/nedim/.rvm/gems/ruby-3.0.2/gems/itamae-1.12.3/lib/itamae/backend.rb:182:in `map'
	from /home/nedim/.rvm/gems/ruby-3.0.2/gems/itamae-1.12.3/lib/itamae/backend.rb:182:in `build_command'
	from /home/nedim/.rvm/gems/ruby-3.0.2/gems/itamae-1.12.3/lib/itamae/backend.rb:49:in `run_command'
	from /home/nedim/.rvm/gems/ruby-3.0.2/gems/itamae-1.12.3/lib/itamae/runner.rb:38:in `initialize'
	from /home/nedim/.rvm/gems/ruby-3.0.2/gems/itamae-1.12.3/lib/itamae/runner.rb:11:in `new'
	from /home/nedim/.rvm/gems/ruby-3.0.2/gems/itamae-1.12.3/lib/itamae/runner.rb:11:in `run'
	from itamae_apply_job.rb:12:in `<main>'
````