### PR TITLE
Support Psych4.x

### DIFF
--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -31,7 +31,7 @@ module Itamae
     def self.options
       @itamae_options ||= super.dup.tap do |options|
         if config = options[:config]
-          options.merge!(YAML.load_file(config))
+          options.merge!(YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(config) : YAML.load(config))
         end
       end
     end

--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -114,7 +114,8 @@ module Itamae
       if @options[:node_yaml]
         path = File.expand_path(@options[:node_yaml])
         Itamae.logger.info "Loading node data from #{path}..."
-        hash.merge!(YAML.load(open(path)) || {})
+        yaml = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(open(path)) : YAML.load(open(path))
+        hash.merge!(yaml || {})
       end
 
       Node.new(hash, @backend)


### PR DESCRIPTION
Since Psych4.0, YAML.load defaults to YAML.safe_load.

FYI https://github.com/ruby/psych/pull/487