### PR TITLE
Support repeatable "node_json" and "node_yaml" options

### DIFF
--- a/itamae.gemspec
+++ b/itamae.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "thor"
+  spec.add_runtime_dependency "thor", ">= 1.0.0"
   spec.add_runtime_dependency "specinfra", [">= 2.64.0", "< 3.0.0"]
   spec.add_runtime_dependency "hashie"
   spec.add_runtime_dependency "ansi"

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -14,8 +14,8 @@ module Itamae
 
     def self.define_exec_options
       option :recipe_graph, type: :string, desc: "[EXPERIMENTAL] Write recipe dependency graph in DOT", banner: "PATH"
-      option :node_json, type: :string, aliases: ['-j']
-      option :node_yaml, type: :string, aliases: ['-y']
+      option :node_json, type: :string, aliases: ['-j'], repeatable: true
+      option :node_yaml, type: :string, aliases: ['-y'], repeatable: true
       option :dry_run, type: :boolean, aliases: ['-n']
       option :shell, type: :string, default: "/bin/sh"
       option :login_shell, type: :boolean, default: false

--- a/spec/unit/lib/itamae/runner_spec.rb
+++ b/spec/unit/lib/itamae/runner_spec.rb
@@ -69,8 +69,6 @@ module Itamae
           expect(runner.node[:array]).to eq [456]
           expect(runner.node[:shared][:foo]).to eq true
           expect(runner.node[:shared][:bar]).to eq false
-        ensure
-          [json_one, json_two, yaml_one, yaml_two].each(&:unlink)
         end
       end
     end

--- a/spec/unit/lib/itamae/runner_spec.rb
+++ b/spec/unit/lib/itamae/runner_spec.rb
@@ -28,5 +28,51 @@ module Itamae
         described_class.run(recipes, :local, {})
       end
     end
+
+    describe "#initialize" do
+      context "with multiple node_json and node_yaml files" do
+        def build_temp_file(data)
+          file = Tempfile.new
+          file.write data
+          file.close
+          file
+        end
+
+        it "merges hashes and overwrites arrays" do
+          json_one = build_temp_file %({ "vars_from_json": { "one": 1 }, "shared": { "foo": true } })
+          json_two = build_temp_file %({ "vars_from_json": { "two": 2 } })
+          yaml_one = build_temp_file %(
+            vars_from_yaml:
+              three: 3
+            array:
+              - 123
+            shared:
+              bar: false
+          )
+          yaml_two = build_temp_file %(
+            vars_from_yaml:
+              four: 4
+            array:
+              - 456
+          )
+
+          runner = described_class.new(
+            spy,
+            node_json: [json_one.path, json_two.path],
+            node_yaml: [yaml_one.path, yaml_two.path]
+          )
+
+          expect(runner.node[:vars_from_json][:one]).to eq 1
+          expect(runner.node[:vars_from_json][:two]).to eq 2
+          expect(runner.node[:vars_from_yaml][:three]).to eq 3
+          expect(runner.node[:vars_from_yaml][:four]).to eq 4
+          expect(runner.node[:array]).to eq [456]
+          expect(runner.node[:shared][:foo]).to eq true
+          expect(runner.node[:shared][:bar]).to eq false
+        ensure
+          [json_one, json_two, yaml_one, yaml_two].each(&:unlink)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Thor supports two ways to pass mutiple values to a flag: via the :array type or via the "repeatable" option. This PR adds the latter.
It allows to pass multiple `node_yaml` and `node_json` files that will all be read and applied to a node.

The logic is as follows:
- Hashes are merged
- Scalars and arrays are overwritten

A common use case for this feature is applying vars to a group of nodes (compare to Ansible's `group_vars` and `host_vars`).

Example:
```sh
  itamae ssh --node-json vars/global.json --node-yaml group.yml --node-yaml node-1.yml recipes.rb
```