### PR TITLE
Made MFA mandatory for gem releases

### DIFF
--- a/itamae.gemspec
+++ b/itamae.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
     spec.metadata["homepage_uri"] = spec.homepage
     spec.metadata["source_code_uri"] = "https://github.com/itamae-kitchen/itamae"
     spec.metadata["changelog_uri"] = "https://github.com/itamae-kitchen/itamae/blob/master/CHANGELOG.md"
+    spec.metadata["rubygems_mfa_required"] = "true"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."


### PR DESCRIPTION
# Motivation
I want to make MFA mandatory for gem security (supply chain attack)

https://blog.rubygems.org/2022/06/13/making-packages-more-secure.html

# What will change after merging this PR?
MFA is requested when `rake release` is running

```
$ bundle exec rake release

(snip)

You have enabled multi-factor authentication. Please enter OTP code.
Code:
```

Please enable MFA on own account 🙏 
https://rubygems.org/settings/edit

![image](https://user-images.githubusercontent.com/608755/174805175-cefaed0f-f943-42d1-ad36-43ef4cf26784.png)
