### PR TITLE
Execute local_ruby_block code inside of chdir-ed block if cwd presented

### DIFF
--- a/lib/itamae/resource/local_ruby_block.rb
+++ b/lib/itamae/resource/local_ruby_block.rb
@@ -5,7 +5,13 @@ module Itamae
       define_attribute :block, type: Proc
 
       def action_run(options)
-        attributes.block.call
+        if attributes[:cwd]
+          Dir.chdir(attributes[:cwd]) do
+            attributes.block.call
+          end
+        else
+          attributes.block.call
+        end
       end
     end
   end

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -527,6 +527,15 @@ local_ruby_block 'execute run_command' do
   end
 end
 
+local_ruby_block "pwd with cwd attribute" do
+  cwd "/tmp"
+  block do
+    unless `pwd`.chomp == "/tmp"
+      raise "working directory mismatched"
+    end
+  end
+end
+
 execute "touch /tmp/subscribed_from_parent" do
   action :nothing
   subscribes :run, 'execute[subscribed from parent]'


### PR DESCRIPTION
"local_ruby_block" execute by itamae's ruby process. The process doesn't change its working directory, which is presented by "cwd" attribute.
I think it's the root cause of issue #353.

I made the local_ruby_block code execute inside of Dir.chdir block if cwd attribute was presented to fix it.
This behavior has existed since 2015. (#146) There might be a recipe that is dependent on current behavior somewhere. Although I couldn't find public itamae recipes that use "local_ruby_block" with "cwd", the change has a small impact, I think.

Fix #353