### PR TITLE
Add Itamae::Runner recipe_files argument data type validation

### DIFF
--- a/lib/itamae/runner.rb
+++ b/lib/itamae/runner.rb
@@ -5,6 +5,10 @@ module Itamae
   class Runner
     class << self
       def run(recipe_files, backend_type, options)
+        unless recipe_files.is_a? Array
+          raise ArgumentError, 'recipe_files must be an Array'
+        end
+
         Itamae.logger.info "Starting Itamae... #{options[:dry_run] ? '(dry-run)' : ''}"
 
         backend = Backend.create(backend_type, options)

--- a/spec/unit/lib/itamae/runner_spec.rb
+++ b/spec/unit/lib/itamae/runner_spec.rb
@@ -27,6 +27,14 @@ module Itamae
         end
         described_class.run(recipes, :local, {})
       end
+
+      it "raises error for invalid recipes argument type" do
+        [nil, "recipe.rb"].each do |recipe|
+          expect do
+            described_class.run(recipe, :local, {})
+          end.to raise_error(ArgumentError, 'recipe_files must be an Array')
+        end
+      end
     end
 
     describe "#initialize" do


### PR DESCRIPTION
It raises `ArgumentError` when recipe_files argument data type isn't an Array.

Ref: Issue https://github.com/itamae-kitchen/itamae/issues/345

