### PR TITLE
Fixed. integration-local on Ruby < 2.6

### DIFF
--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -82,7 +82,10 @@ class IntegrationLocalSpecRunner
   end
 
   def prepare
-    docker_exec 'gem', 'install', 'bundler'
+    # Install the same version of bundler into the Docker container as is installed locally
+    current_bundler_version = /([0-9.]+)/.match(`bundle -v`).captures[0]
+    docker_exec 'gem', 'install', 'bundler', '-v', current_bundler_version
+
     docker_exec 'bundle', 'install', options: %w[--workdir /itamae]
     docker_exec 'apt-get', 'update', '-y'
     docker_exec 'apt-get', 'install', 'locales', 'sudo', '-y'


### PR DESCRIPTION
Latest bundler requires Ruby 2.6+

```
docker exec --env LANG=en_US.utf8 itamae gem install bundler
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.3.26. Try installing it with `gem install bundler -v 2.3.26`
	bundler requires Ruby version >= 2.6.0. The current ruby version is 2.3.8.459.
rake aborted!
Command failed with status (1): [docker exec --env LANG=en_US.utf8 itamae g...]
/home/runner/work/itamae/itamae/tasks/integration_local_spec.rb:115:in `docker_exec'
/home/runner/work/itamae/itamae/tasks/integration_local_spec.rb:85:in `prepare'
/home/runner/work/itamae/itamae/tasks/integration_local_spec.rb:70:in `initialize'
/home/runner/work/itamae/itamae/tasks/integration_local_spec.rb:13:in `new'
/home/runner/work/itamae/itamae/tasks/integration_local_spec.rb:13:in `block (2 levels) in <top (required)>'
/home/runner/work/itamae/itamae/vendor/bundle/ruby/2.3.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/opt/hostedtoolcache/Ruby/2.3.8/x64/bin/bundle:22:in `load'
/opt/hostedtoolcache/Ruby/2.3.8/x64/bin/bundle:22:in `<main>'
Tasks: TOP => spec:integration:local:main
(See full trace by running task with --trace)
Error: Process completed with exit code 1.
```

ref. https://github.com/itamae-kitchen/itamae/actions/runs/3812297436/jobs/6485429277

So, install the same version of bundler into the Docker container as is installed locally (For CI, version already installed with ruby/setup-ruby)