### PR TITLE
Refactor: Extract to another workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,155 +13,7 @@ on:
     - cron: "0 0 * * 5" # JST 9:00 (Fri)
 
 jobs:
-  unit:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-
-      matrix:
-        ruby:
-          - "2.3"
-          - "2.4"
-          - "2.5"
-          - "2.6"
-          - "2.7"
-          - "3.0"
-          - "3.1"
-          - "3.2"
-        rubyopt:
-          - ""
-          - "--jit"
-          - "--yjit"
-        exclude:
-          # --jit is available since MRI 2.6
-          - ruby:    "2.3"
-            rubyopt: "--jit"
-          - ruby:    "2.4"
-            rubyopt: "--jit"
-          - ruby:    "2.5"
-            rubyopt: "--jit"
-          # --yjit is available since MRI 3.1
-          - ruby:    "2.3"
-            rubyopt: "--yjit"
-          - ruby:    "2.4"
-            rubyopt: "--yjit"
-          - ruby:    "2.5"
-            rubyopt: "--yjit"
-          - ruby:    "2.6"
-            rubyopt: "--yjit"
-          - ruby:    "2.7"
-            rubyopt: "--yjit"
-          - ruby:    "3.0"
-            rubyopt: "--yjit"
-    env:
-      RUBYOPT: ${{ matrix.rubyopt }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - run: bundle update
-
-      - run: bundle exec rake spec:unit
-
-      - name: Slack Notification (not success)
-        uses: lazy-actions/slatify@master
-        if: "! success()"
-        continue-on-error: true
-        with:
-          job_name: ${{ format('*unit* ({0},{1})', matrix.ruby, matrix.rubyopt) }}
-          type: ${{ job.status }}
-          icon_emoji: ":octocat:"
-          url: ${{ secrets.SLACK_WEBHOOK }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  integration-docker:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-
-      matrix:
-        ruby:
-          - "2.3"
-          - "2.4"
-          - "2.5"
-          - "2.6"
-          - "2.7"
-          - "3.0"
-          - "3.1"
-          - "3.2"
-        rubyopt:
-          - ""
-          - "--jit"
-          - "--yjit"
-        image:
-          - ubuntu:trusty
-        exclude:
-          # --jit is available since MRI 2.6
-          - ruby:    "2.3"
-            rubyopt: "--jit"
-          - ruby:    "2.4"
-            rubyopt: "--jit"
-          - ruby:    "2.5"
-            rubyopt: "--jit"
-          # --yjit is available since MRI 3.1
-          - ruby:    "2.3"
-            rubyopt: "--yjit"
-          - ruby:    "2.4"
-            rubyopt: "--yjit"
-          - ruby:    "2.5"
-            rubyopt: "--yjit"
-          - ruby:    "2.6"
-            rubyopt: "--yjit"
-          - ruby:    "2.7"
-            rubyopt: "--yjit"
-          - ruby:    "3.0"
-            rubyopt: "--yjit"
-
-    env:
-      RUBYOPT: ${{ matrix.rubyopt }}
-      TEST_IMAGE: ${{ matrix.image }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - run: bundle update
-
-      - run: bundle exec rake spec:integration:docker:boot
-
-      - run: bundle exec rake spec:integration:docker:provision
-        env:
-          # FIXME: avoid error for "Command `chmod 777 /tmp/itamae_tmp` failed. (exit status: 1)"
-          ITAMAE_TMP_DIR: /var/tmp/itamae_tmp
-
-      - run: bundle exec rake spec:integration:docker:serverspec
-      - run: bundle exec rake spec:integration:docker:clean_docker_container
-
-      - name: Slack Notification (not success)
-        uses: lazy-actions/slatify@master
-        if: "! success()"
-        continue-on-error: true
-        with:
-          job_name: ${{ format('*integration-docker* ({0},{1},{2})', matrix.ruby, matrix.rubyopt, matrix.image) }}
-          type: ${{ job.status }}
-          icon_emoji: ":octocat:"
-          url: ${{ secrets.SLACK_WEBHOOK }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  integration-local:
-    runs-on: ubuntu-latest
-
+  test_main:
     strategy:
       fail-fast: false
 
@@ -201,38 +53,16 @@ jobs:
           - ruby:    "3.0"
             rubyopt: "--yjit"
 
-    env:
-      RUBYOPT: ${{ matrix.rubyopt }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - run: bundle update
-
-      - run: bundle exec rake spec:integration:local:main
-      - run: bundle exec rake spec:integration:local:ordinary_user
-
-      - name: Slack Notification (not success)
-        uses: lazy-actions/slatify@master
-        if: "! success()"
-        continue-on-error: true
-        with:
-          job_name: ${{ format('*integration-local* ({0},{1})', matrix.ruby, matrix.rubyopt) }}
-          type: ${{ job.status }}
-          icon_emoji: ":octocat:"
-          url: ${{ secrets.SLACK_WEBHOOK }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/test_main.yml
+    with:
+      ruby: ${{ matrix.ruby }}
+      rubyopt: ${{ matrix.rubyopt }}
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   notify:
     needs:
-      - unit
-      - integration-docker
-      - integration-local
+      - test_main
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -1,0 +1,116 @@
+name: test_main
+
+on:
+  workflow_call:
+    inputs:
+      ruby:
+        required: true
+        type: string
+      rubyopt:
+        required: false
+        type: string
+        default: ""
+    secrets:
+      SLACK_WEBHOOK:
+        required: true
+
+env:
+  RUBYOPT: ${{ inputs.rubyopt }}
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ inputs.ruby }}
+          bundler-cache: true
+
+      - run: bundle update
+
+      - run: bundle exec rake spec:unit
+
+      - name: Slack Notification (not success)
+        uses: lazy-actions/slatify@master
+        if: "! success()"
+        continue-on-error: true
+        with:
+          job_name: ${{ format('*unit* ({0},{1})', inputs.ruby, inputs.rubyopt) }}
+          type: ${{ job.status }}
+          icon_emoji: ":octocat:"
+          url: ${{ secrets.SLACK_WEBHOOK }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  integration-docker:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        image:
+          - ubuntu:trusty
+
+    env:
+      TEST_IMAGE: ${{ matrix.image }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ inputs.ruby }}
+          bundler-cache: true
+
+      - run: bundle update
+
+      - run: bundle exec rake spec:integration:docker:boot
+
+      - run: bundle exec rake spec:integration:docker:provision
+        env:
+          # FIXME: avoid error for "Command `chmod 777 /tmp/itamae_tmp` failed. (exit status: 1)"
+          ITAMAE_TMP_DIR: /var/tmp/itamae_tmp
+
+      - run: bundle exec rake spec:integration:docker:serverspec
+      - run: bundle exec rake spec:integration:docker:clean_docker_container
+
+      - name: Slack Notification (not success)
+        uses: lazy-actions/slatify@master
+        if: "! success()"
+        continue-on-error: true
+        with:
+          job_name: ${{ format('*integration-docker* ({0},{1},{2})', inputs.ruby, inputs.rubyopt, matrix.image) }}
+          type: ${{ job.status }}
+          icon_emoji: ":octocat:"
+          url: ${{ secrets.SLACK_WEBHOOK }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  integration-local:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ inputs.ruby }}
+          bundler-cache: true
+
+      - run: bundle update
+
+      - run: bundle exec rake spec:integration:local:main
+      - run: bundle exec rake spec:integration:local:ordinary_user
+
+      - name: Slack Notification (not success)
+        uses: lazy-actions/slatify@master
+        if: "! success()"
+        continue-on-error: true
+        with:
+          job_name: ${{ format('*integration-local* ({0},{1})', inputs.ruby, inputs.rubyopt) }}
+          type: ${{ job.status }}
+          icon_emoji: ":octocat:"
+          url: ${{ secrets.SLACK_WEBHOOK }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Motivation
It is confusing when adding a new Ruby version because we have to add the same one to multiple jobs.

e.g. 26fa2d7e81e20127b1d0937756dece5b6483639d

So I refactored it by consolidating the matrix in one place

c.f.

* https://docs.github.com/en/actions/using-workflows/reusing-workflows
* https://github.blog/changelog/2021-11-24-github-actions-reusable-workflows-are-generally-available/