### PR TITLE
Stop testing with ruby:2.3 + integration-local

### DIFF
--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           ruby-version: ${{ inputs.ruby }}
           bundler-cache: true
+          bundler: default
 
       - run: bundle update
 
@@ -64,6 +65,7 @@ jobs:
         with:
           ruby-version: ${{ inputs.ruby }}
           bundler-cache: true
+          bundler: default
 
       - run: bundle update
 
@@ -101,6 +103,7 @@ jobs:
         with:
           ruby-version: ${{ inputs.ruby }}
           bundler-cache: true
+          bundler: default
 
       - run: bundle update
 

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -91,6 +91,9 @@ jobs:
   integration-local:
     runs-on: ubuntu-latest
 
+    # NOTE: Use debian buster+
+    if: ${{ inputs.ruby >= '2.4' }}
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -93,7 +93,7 @@ jobs:
   integration-local:
     runs-on: ubuntu-latest
 
-    # NOTE: Use debian buster+
+    # NOTE: When ruby is 2.3, tests run on stretch. But stretch is already EOL and didn't work apt-get
     if: ${{ inputs.ruby >= '2.4' }}
 
     steps:


### PR DESCRIPTION
Suppress this :tired_face:
https://github.com/itamae-kitchen/itamae/actions/runs/4825636636/jobs/8606093948

# Why?
`ruby:2.3` image is based on Debian Stretch. However, Stretch is already EOL and cannot be `apt-get update`

```
$  docker run --rm -it ruby:2.3 bash
root@63c41c585ef0:/# cat /etc/debian_version
9.8

root@63c41c585ef0:/# apt-get update
Ign:1 http://security.debian.org/debian-security stretch/updates InRelease
Ign:2 http://security.debian.org/debian-security stretch/updates Release
Ign:3 http://deb.debian.org/debian stretch InRelease
Ign:4 http://deb.debian.org/debian stretch-updates InRelease
Ign:5 http://deb.debian.org/debian stretch Release
Ign:6 http://deb.debian.org/debian stretch-updates Release
Ign:7 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
Ign:8 http://security.debian.org/debian-security stretch/updates/main all Packages
Ign:9 http://deb.debian.org/debian stretch/main arm64 Packages
Ign:10 http://deb.debian.org/debian stretch/main all Packages
Ign:7 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
Ign:8 http://security.debian.org/debian-security stretch/updates/main all Packages
Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
Ign:7 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
Ign:8 http://security.debian.org/debian-security stretch/updates/main all Packages
Ign:9 http://deb.debian.org/debian stretch/main arm64 Packages
Ign:10 http://deb.debian.org/debian stretch/main all Packages
Ign:7 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
Ign:8 http://security.debian.org/debian-security stretch/updates/main all Packages
Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
Ign:7 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
Ign:8 http://security.debian.org/debian-security stretch/updates/main all Packages
Ign:9 http://deb.debian.org/debian stretch/main arm64 Packages
Ign:10 http://deb.debian.org/debian stretch/main all Packages
Err:7 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
  404  Not Found
Ign:8 http://security.debian.org/debian-security stretch/updates/main all Packages
Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
Ign:9 http://deb.debian.org/debian stretch/main arm64 Packages
Ign:10 http://deb.debian.org/debian stretch/main all Packages
Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
Ign:9 http://deb.debian.org/debian stretch/main arm64 Packages
Ign:10 http://deb.debian.org/debian stretch/main all Packages
Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
Err:9 http://deb.debian.org/debian stretch/main arm64 Packages
  404  Not Found
Ign:10 http://deb.debian.org/debian stretch/main all Packages
Err:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
  404  Not Found
Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
Reading package lists... Done
W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use.
N: See apt-secure(8) manpage for repository creation and user configuration details.
W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use.
N: See apt-secure(8) manpage for repository creation and user configuration details.
W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-arm64/Packages  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-arm64/Packages  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-arm64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.

root@63c41c585ef0:/# echo $?
100
```

Therefore, I would like to require Ruby 2.4+(Debian buster+) for `integration-docker` :cry:

```
$ docker run --rm -it ruby:2.4 bash
root@c8da5af31d18:/# cat /etc/debian_version
10.3
```

