### PR TITLE
Exclude duplicated test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,12 @@ jobs:
           - ruby:    "3.0"
             rubyopt: "--yjit"
 
+          # --jit is same to --yjit since MRI 3.2 (don't test both `--jit` and `--yjit`)
+          - ruby:    "3.2"
+            rubyopt: "--yjit"
+          - ruby:    "3.3"
+            rubyopt: "--yjit"
+
     uses: ./.github/workflows/test_main.yml
     with:
       ruby: ${{ matrix.ruby }}


### PR DESCRIPTION
`--jit` is same to `--yjit` since MRI 3.2

```
$ RBENV_VERSION=3.0.5 ruby --help | grep " --jit "
  --jit           enable JIT with default options (experimental)

$ RBENV_VERSION=3.1.4 ruby --help | grep " --jit "
  --jit           enable JIT for the platform, same as --mjit (experimental)

$ RBENV_VERSION=3.2.2 ruby --help | grep " --jit "
  --jit           enable JIT for the platform, same as --yjit

$ RBENV_VERSION=3.3.0 ruby --help | grep " --jit "
  --jit           enable JIT for the platform, same as --yjit
```

Therefore, since Ruby 3.2, I don't test both `--jit` and `--yjit`.