### PR TITLE
Update default ubuntu on integration spec to xenial

### DIFF
--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -53,6 +53,7 @@ jobs:
       matrix:
         image:
           - ubuntu:trusty
+          - ubuntu:xenial
 
     env:
       TEST_IMAGE: ${{ matrix.image }}

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ end
 desc 'Run unit and integration specs.'
 task :spec => ['spec:unit', 'spec:integration:all']
 
-TEST_IMAGE = ENV["TEST_IMAGE"] || "ubuntu:trusty"
+TEST_IMAGE = ENV["TEST_IMAGE"] || "ubuntu:xenial"
 
 namespace :spec do
   RSpec::Core::RakeTask.new("unit") do |task|


### PR DESCRIPTION
## what

## why
trusty eol date is 2024-04-02

https://wiki.ubuntu.com/Releases