### PR TITLE
Migrate to act10ns/slack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,12 +113,9 @@ jobs:
 
     steps:
       - name: Slack Notification (success)
-        uses: lazy-actions/slatify@master
+        uses: act10ns/slack@v2
         if: always()
         continue-on-error: true
         with:
-          job_name: '*notify*'
-          type: ${{ job.status }}
-          icon_emoji: ":octocat:"
-          url: ${{ secrets.SLACK_WEBHOOK }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Slack Notification (success)
-        uses: act10ns/slack@v2
+        uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2.2.0
         if: always()
         continue-on-error: true
         with:

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -37,15 +37,13 @@ jobs:
           RUBYOPT: ${{ inputs.rubyopt }}
 
       - name: Slack Notification (not success)
-        uses: lazy-actions/slatify@master
+        uses: act10ns/slack@v2
         if: "! success()"
         continue-on-error: true
         with:
-          job_name: ${{ format('*unit* ({0},{1})', inputs.ruby, inputs.rubyopt) }}
-          type: ${{ job.status }}
-          icon_emoji: ":octocat:"
-          url: ${{ secrets.SLACK_WEBHOOK }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          matrix: ${{ toJson(matrix) }}
 
   integration-docker:
     runs-on: ubuntu-latest
@@ -92,15 +90,13 @@ jobs:
           RUBYOPT: ${{ inputs.rubyopt }}
 
       - name: Slack Notification (not success)
-        uses: lazy-actions/slatify@master
+        uses: act10ns/slack@v2
         if: "! success()"
         continue-on-error: true
         with:
-          job_name: ${{ format('*integration-docker* ({0},{1},{2})', inputs.ruby, inputs.rubyopt, matrix.image) }}
-          type: ${{ job.status }}
-          icon_emoji: ":octocat:"
-          url: ${{ secrets.SLACK_WEBHOOK }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          matrix: ${{ toJson(matrix) }}
 
   integration-local:
     runs-on: ubuntu-latest
@@ -131,12 +127,10 @@ jobs:
           RUBYOPT: ${{ inputs.rubyopt }}
 
       - name: Slack Notification (not success)
-        uses: lazy-actions/slatify@master
+        uses: act10ns/slack@v2
         if: "! success()"
         continue-on-error: true
         with:
-          job_name: ${{ format('*integration-local* ({0},{1})', inputs.ruby, inputs.rubyopt) }}
-          type: ${{ job.status }}
-          icon_emoji: ":octocat:"
-          url: ${{ secrets.SLACK_WEBHOOK }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          matrix: ${{ toJson(matrix) }}

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}
-          matrix: ${{ toJson(matrix) }}
+          inputs: ${{ toJson(inputs) }}
 
   integration-docker:
     runs-on: ubuntu-latest
@@ -133,4 +133,4 @@ jobs:
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}
-          matrix: ${{ toJson(matrix) }}
+          inputs: ${{ toJson(inputs) }}

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -37,7 +37,7 @@ jobs:
           RUBYOPT: ${{ inputs.rubyopt }}
 
       - name: Slack Notification (not success)
-        uses: act10ns/slack@v2
+        uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2.2.0
         if: "! success()"
         continue-on-error: true
         with:
@@ -90,7 +90,7 @@ jobs:
           RUBYOPT: ${{ inputs.rubyopt }}
 
       - name: Slack Notification (not success)
-        uses: act10ns/slack@v2
+        uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2.2.0
         if: "! success()"
         continue-on-error: true
         with:
@@ -127,7 +127,7 @@ jobs:
           RUBYOPT: ${{ inputs.rubyopt }}
 
       - name: Slack Notification (not success)
-        uses: act10ns/slack@v2
+        uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2.2.0
         if: "! success()"
         continue-on-error: true
         with:


### PR DESCRIPTION
# Motivation
https://github.com/lazy-actions/slatify is already not maintained and my patch has been neglected for a long time 😭 
https://github.com/lazy-actions/slatify/pull/99

So I migrated to a new Slack notification action.
https://github.com/act10ns/slack

My patch is also incorporated in the latest version.

* https://github.com/act10ns/slack/releases/tag/v2.1.0
* https://github.com/act10ns/slack/pull/268

This has allowed we to greatly reduce the number of configurations :triumph:

# Example
## Before
<img width="440" height="175" alt="image" src="https://github.com/user-attachments/assets/b40b1464-f612-4a82-b3fe-832247d3470c" />

## After
<img width="522" height="232" alt="image" src="https://github.com/user-attachments/assets/c9672cf4-5515-4cd4-b945-9cfbbafa28f9" />
