### PR TITLE
Prepare for supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           ruby-version: ${{ inputs.ruby }}
           bundler-cache: true
@@ -62,9 +62,9 @@ jobs:
       SKIP_HTTP_REQUEST_TEST: ${{ inputs.skip_http_request_test }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           ruby-version: ${{ inputs.ruby }}
           bundler-cache: true
@@ -112,9 +112,9 @@ jobs:
       SKIP_HTTP_REQUEST_TEST: ${{ inputs.skip_http_request_test }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           ruby-version: ${{ inputs.ruby }}
           bundler-cache: true


### PR DESCRIPTION
Recently, supply chain attacks via GitHub Actions have become a serious issue 😭 

In this PR, we have introduced the following configurations to mitigate the risk of supply chain attacks:

1. Pin actions to a full-length commit SHA with https://github.com/suzuki-shunsuke/pinact
    * ref. https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions
2. Configure a cooldown period for Dependabot
    * ref. https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-