### PR TITLE
Run http_request integration tests against a local go-httpbin server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,15 +93,6 @@ jobs:
     with:
       ruby: ${{ matrix.ruby }}
       rubyopt: ${{ matrix.rubyopt }}
-
-      # This repository uses matrix to run 50+ builds in a pipeline.
-      # This results in simultaneous requests being sent to httpbin.org,
-      # similar to a DDoS attack, often causing 500 errors and test failures.
-      #
-      # e.g. https://github.com/itamae-kitchen/itamae/actions/runs/17045210601/job/48319099479?pr=379
-      #
-      # Therefore, I suppressed simultaneous requests to httpbin.org.
-      skip_http_request_test: ${{ (matrix.ruby == '2.3' && matrix.rubyopt == '') && 'false' || 'true' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -70,6 +70,10 @@ jobs:
 
       - run: bundle update
 
+      - run: bundle exec rake spec:integration:docker:httpbin_start
+        env:
+          RUBYOPT: ${{ inputs.rubyopt }}
+
       - run: bundle exec rake spec:integration:docker:boot
         env:
           RUBYOPT: ${{ inputs.rubyopt }}
@@ -86,6 +90,11 @@ jobs:
           RUBYOPT: ${{ inputs.rubyopt }}
 
       - run: bundle exec rake spec:integration:docker:clean_docker_container
+        env:
+          RUBYOPT: ${{ inputs.rubyopt }}
+
+      - run: bundle exec rake spec:integration:docker:httpbin_stop
+        if: always()
         env:
           RUBYOPT: ${{ inputs.rubyopt }}
 

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -10,9 +10,6 @@ on:
         required: false
         type: string
         default: ""
-      skip_http_request_test:
-        required: true
-        type: string
     secrets:
       SLACK_WEBHOOK:
         required: true
@@ -57,7 +54,6 @@ jobs:
 
     env:
       TEST_IMAGE: ${{ matrix.image }}
-      SKIP_HTTP_REQUEST_TEST: ${{ inputs.skip_http_request_test }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -112,9 +108,6 @@ jobs:
 
     # NOTE: When ruby is 2.5, tests run on buster. But buster is already EOL and didn't work apt-get
     if: ${{ inputs.ruby >= '2.6' }}
-
-    env:
-      SKIP_HTTP_REQUEST_TEST: ${{ inputs.skip_http_request_test }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/Rakefile
+++ b/Rakefile
@@ -24,9 +24,19 @@ namespace :spec do
     task :all => ['spec:integration:docker', 'spec:integration:local']
 
     desc "Run provision and specs"
-    task :docker => ["docker:boot", "docker:provision", "docker:serverspec", 'docker:clean_docker_container']
+    task :docker => ["docker:httpbin_start", "docker:boot", "docker:provision", "docker:serverspec", 'docker:clean_docker_container', "docker:httpbin_stop"]
 
     namespace :docker do
+      desc "Start a local go-httpbin server for http_request tests"
+      task :httpbin_start do
+        HttpbinServer.start
+      end
+
+      desc "Stop the local go-httpbin server"
+      task :httpbin_stop do
+        HttpbinServer.stop
+      end
+
       desc "Run docker"
       task :boot do
         sh "docker run --env SKIP_HTTP_REQUEST_TEST --privileged -d --name #{container_name} #{TEST_IMAGE} /sbin/init"

--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ namespace :spec do
 
       desc "Run docker"
       task :boot do
-        sh "docker run --env SKIP_HTTP_REQUEST_TEST --privileged -d --name #{container_name} #{TEST_IMAGE} /sbin/init"
+        sh "docker run --privileged -d --name #{container_name} #{TEST_IMAGE} /sbin/init"
       end
 
       desc "Run itamae"

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -79,29 +79,29 @@ end
 
 describe file('/tmp/http_request.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
   it { should be_file }
-  its(:content) { should match(/"from":\s*"itamae"/) }
+  its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
 end
 
 describe file('/tmp/http_request_delete.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
   it { should be_file }
-  its(:content) { should match(/"from":\s*"itamae"/) }
+  its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
 end
 
 describe file('/tmp/http_request_post.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
   it { should be_file }
-  its(:content) { should match(/"from":\s*"itamae"/) }
-  its(:content) { should match(/"love":\s*"sushi"/) }
+  its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
+  its(:content) { should match(/"love":\s*\[?\s*"sushi"/) }
 end
 
 describe file('/tmp/http_request_put.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
   it { should be_file }
-  its(:content) { should match(/"from":\s*"itamae"/) }
-  its(:content) { should match(/"love":\s*"sushi"/) }
+  its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
+  its(:content) { should match(/"love":\s*\[?\s*"sushi"/) }
 end
 
 describe file('/tmp/http_request_headers.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
   it { should be_file }
-  its(:content) { should match(/"User-Agent":\s*"Itamae"/) }
+  its(:content) { should match(/"User-Agent":\s*\[?\s*"Itamae"/) }
 end
 
 xdescribe file('/tmp/http_request_redirect.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do

--- a/spec/integration/default_spec.rb
+++ b/spec/integration/default_spec.rb
@@ -77,34 +77,34 @@ describe file('/tmp/never_exist2') do
   it { should_not be_file }
 end
 
-describe file('/tmp/http_request.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
+describe file('/tmp/http_request.html') do
   it { should be_file }
   its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
 end
 
-describe file('/tmp/http_request_delete.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
+describe file('/tmp/http_request_delete.html') do
   it { should be_file }
   its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
 end
 
-describe file('/tmp/http_request_post.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
-  it { should be_file }
-  its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
-  its(:content) { should match(/"love":\s*\[?\s*"sushi"/) }
-end
-
-describe file('/tmp/http_request_put.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
+describe file('/tmp/http_request_post.html') do
   it { should be_file }
   its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
   its(:content) { should match(/"love":\s*\[?\s*"sushi"/) }
 end
 
-describe file('/tmp/http_request_headers.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
+describe file('/tmp/http_request_put.html') do
+  it { should be_file }
+  its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
+  its(:content) { should match(/"love":\s*\[?\s*"sushi"/) }
+end
+
+describe file('/tmp/http_request_headers.html') do
   it { should be_file }
   its(:content) { should match(/"User-Agent":\s*\[?\s*"Itamae"/) }
 end
 
-xdescribe file('/tmp/http_request_redirect.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
+xdescribe file('/tmp/http_request_redirect.html') do
   it { should be_file }
   its(:content) { should match(/"from":\s*"itamae"/) }
 end

--- a/spec/integration/ordinary_user_spec.rb
+++ b/spec/integration/ordinary_user_spec.rb
@@ -88,14 +88,14 @@ describe file('/tmp/http_request.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] =
   it { should be_file }
   it { should be_owned_by "ordinary_san" }
   it { should be_grouped_into "ordinary_san" }
-  its(:content) { should match(/"from":\s*"itamae"/) }
+  its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
 end
 
 describe file('/tmp/http_request_root.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
   it { should be_file }
   it { should be_owned_by "root" }
   it { should be_grouped_into "root" }
-  its(:content) { should match(/"from":\s*"itamae"/) }
+  its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
 end
 
 %w[/tmp/http_request_another_ordinary.html /tmp/http_request_another_ordinary_with_root.html].each do |path|
@@ -103,6 +103,6 @@ end
     it { should be_file }
     it { should be_owned_by "itamae" }
     it { should be_grouped_into "itamae" }
-    its(:content) { should match(/"from":\s*"itamae"/) }
+    its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
   end
 end

--- a/spec/integration/ordinary_user_spec.rb
+++ b/spec/integration/ordinary_user_spec.rb
@@ -84,14 +84,14 @@ end
 
 ###
 
-describe file('/tmp/http_request.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true" do
+describe file('/tmp/http_request.html') do
   it { should be_file }
   it { should be_owned_by "ordinary_san" }
   it { should be_grouped_into "ordinary_san" }
   its(:content) { should match(/"from":\s*\[?\s*"itamae"/) }
 end
 
-describe file('/tmp/http_request_root.html'), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
+describe file('/tmp/http_request_root.html') do
   it { should be_file }
   it { should be_owned_by "root" }
   it { should be_grouped_into "root" }
@@ -99,7 +99,7 @@ describe file('/tmp/http_request_root.html'), unless: ENV["SKIP_HTTP_REQUEST_TES
 end
 
 %w[/tmp/http_request_another_ordinary.html /tmp/http_request_another_ordinary_with_root.html].each do |path|
-  describe file(path), unless: ENV["SKIP_HTTP_REQUEST_TEST"] == "true"  do
+  describe file(path) do
     it { should be_file }
     it { should be_owned_by "itamae" }
     it { should be_grouped_into "itamae" }

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -193,35 +193,39 @@ end
 ######
 
 unless ENV["SKIP_HTTP_REQUEST_TEST"] == "true"
+  httpbin_url = ENV.fetch("HTTPBIN_URL") { "http://127.0.0.1:#{ENV.fetch('HTTPBIN_HOST_PORT', '8080')}" }
+
   http_request "/tmp/http_request.html" do
-    url "https://httpbin.org/get?from=itamae"
+    url "#{httpbin_url}/get?from=itamae"
   end
 
   http_request "/tmp/http_request_delete.html" do
     action :delete
-    url "https://httpbin.org/delete?from=itamae"
+    url "#{httpbin_url}/delete?from=itamae"
   end
 
   http_request "/tmp/http_request_post.html" do
     action :post
+    headers "Content-Type" => "application/x-www-form-urlencoded"
     message "love=sushi"
-    url "https://httpbin.org/post?from=itamae"
+    url "#{httpbin_url}/post?from=itamae"
   end
 
   http_request "/tmp/http_request_put.html" do
     action :put
+    headers "Content-Type" => "application/x-www-form-urlencoded"
     message "love=sushi"
-    url "https://httpbin.org/put?from=itamae"
+    url "#{httpbin_url}/put?from=itamae"
   end
 
   http_request "/tmp/http_request_headers.html" do
     headers "User-Agent" => "Itamae"
-    url "https://httpbin.org/get"
+    url "#{httpbin_url}/get"
   end
 
   # http_request "/tmp/http_request_redirect.html" do
   #   redirect_limit 1
-  #   url "https://httpbin.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fget%3Ffrom%3Ditamae"
+  #   url "#{httpbin_url}/redirect-to?url=#{httpbin_url}/get%3Ffrom%3Ditamae"
   # end
 end
 

--- a/spec/integration/recipes/default.rb
+++ b/spec/integration/recipes/default.rb
@@ -192,42 +192,40 @@ end
 
 ######
 
-unless ENV["SKIP_HTTP_REQUEST_TEST"] == "true"
-  httpbin_url = ENV.fetch("HTTPBIN_URL") { "http://127.0.0.1:#{ENV.fetch('HTTPBIN_HOST_PORT', '8080')}" }
+httpbin_url = ENV.fetch("HTTPBIN_URL") { "http://127.0.0.1:#{ENV.fetch('HTTPBIN_HOST_PORT', '8080')}" }
 
-  http_request "/tmp/http_request.html" do
-    url "#{httpbin_url}/get?from=itamae"
-  end
-
-  http_request "/tmp/http_request_delete.html" do
-    action :delete
-    url "#{httpbin_url}/delete?from=itamae"
-  end
-
-  http_request "/tmp/http_request_post.html" do
-    action :post
-    headers "Content-Type" => "application/x-www-form-urlencoded"
-    message "love=sushi"
-    url "#{httpbin_url}/post?from=itamae"
-  end
-
-  http_request "/tmp/http_request_put.html" do
-    action :put
-    headers "Content-Type" => "application/x-www-form-urlencoded"
-    message "love=sushi"
-    url "#{httpbin_url}/put?from=itamae"
-  end
-
-  http_request "/tmp/http_request_headers.html" do
-    headers "User-Agent" => "Itamae"
-    url "#{httpbin_url}/get"
-  end
-
-  # http_request "/tmp/http_request_redirect.html" do
-  #   redirect_limit 1
-  #   url "#{httpbin_url}/redirect-to?url=#{httpbin_url}/get%3Ffrom%3Ditamae"
-  # end
+http_request "/tmp/http_request.html" do
+  url "#{httpbin_url}/get?from=itamae"
 end
+
+http_request "/tmp/http_request_delete.html" do
+  action :delete
+  url "#{httpbin_url}/delete?from=itamae"
+end
+
+http_request "/tmp/http_request_post.html" do
+  action :post
+  headers "Content-Type" => "application/x-www-form-urlencoded"
+  message "love=sushi"
+  url "#{httpbin_url}/post?from=itamae"
+end
+
+http_request "/tmp/http_request_put.html" do
+  action :put
+  headers "Content-Type" => "application/x-www-form-urlencoded"
+  message "love=sushi"
+  url "#{httpbin_url}/put?from=itamae"
+end
+
+http_request "/tmp/http_request_headers.html" do
+  headers "User-Agent" => "Itamae"
+  url "#{httpbin_url}/get"
+end
+
+# http_request "/tmp/http_request_redirect.html" do
+#   redirect_limit 1
+#   url "#{httpbin_url}/redirect-to?url=#{httpbin_url}/get%3Ffrom%3Ditamae"
+# end
 
 link "/tmp-link" do
   to "/tmp"

--- a/spec/integration/recipes/ordinary_user.rb
+++ b/spec/integration/recipes/ordinary_user.rb
@@ -84,28 +84,30 @@ end
 ###
 
 unless ENV["SKIP_HTTP_REQUEST_TEST"] == "true"
+  httpbin_url = ENV.fetch("HTTPBIN_URL") { "http://127.0.0.1:#{ENV.fetch('HTTPBIN_HOST_PORT', '8080')}" }
+
   http_request "/tmp/http_request.html" do
-    url "https://httpbin.org/get?from=itamae"
+    url "#{httpbin_url}/get?from=itamae"
   end
 
   http_request "/tmp/http_request_root.html" do
     user 'root'
     owner 'root'
     group 'root'
-    url "https://httpbin.org/get?from=itamae"
+    url "#{httpbin_url}/get?from=itamae"
   end
 
   http_request "/tmp/http_request_another_ordinary.html" do
     user 'itamae'
     owner 'itamae'
     group 'itamae'
-    url "https://httpbin.org/get?from=itamae"
+    url "#{httpbin_url}/get?from=itamae"
   end
 
   http_request "/tmp/http_request_another_ordinary_with_root.html" do
     user 'root'
     owner 'itamae'
     group 'itamae'
-    url "https://httpbin.org/get?from=itamae"
+    url "#{httpbin_url}/get?from=itamae"
   end
 end

--- a/spec/integration/recipes/ordinary_user.rb
+++ b/spec/integration/recipes/ordinary_user.rb
@@ -83,31 +83,29 @@ end
 
 ###
 
-unless ENV["SKIP_HTTP_REQUEST_TEST"] == "true"
-  httpbin_url = ENV.fetch("HTTPBIN_URL") { "http://127.0.0.1:#{ENV.fetch('HTTPBIN_HOST_PORT', '8080')}" }
+httpbin_url = ENV.fetch("HTTPBIN_URL") { "http://127.0.0.1:#{ENV.fetch('HTTPBIN_HOST_PORT', '8080')}" }
 
-  http_request "/tmp/http_request.html" do
-    url "#{httpbin_url}/get?from=itamae"
-  end
+http_request "/tmp/http_request.html" do
+  url "#{httpbin_url}/get?from=itamae"
+end
 
-  http_request "/tmp/http_request_root.html" do
-    user 'root'
-    owner 'root'
-    group 'root'
-    url "#{httpbin_url}/get?from=itamae"
-  end
+http_request "/tmp/http_request_root.html" do
+  user 'root'
+  owner 'root'
+  group 'root'
+  url "#{httpbin_url}/get?from=itamae"
+end
 
-  http_request "/tmp/http_request_another_ordinary.html" do
-    user 'itamae'
-    owner 'itamae'
-    group 'itamae'
-    url "#{httpbin_url}/get?from=itamae"
-  end
+http_request "/tmp/http_request_another_ordinary.html" do
+  user 'itamae'
+  owner 'itamae'
+  group 'itamae'
+  url "#{httpbin_url}/get?from=itamae"
+end
 
-  http_request "/tmp/http_request_another_ordinary_with_root.html" do
-    user 'root'
-    owner 'itamae'
-    group 'itamae'
-    url "#{httpbin_url}/get?from=itamae"
-  end
+http_request "/tmp/http_request_another_ordinary_with_root.html" do
+  user 'root'
+  owner 'itamae'
+  group 'itamae'
+  url "#{httpbin_url}/get?from=itamae"
 end

--- a/tasks/httpbin_server.rb
+++ b/tasks/httpbin_server.rb
@@ -1,0 +1,63 @@
+# Manage a local mccutchen/go-httpbin container for the integration tests.
+#
+# The public httpbin.org service is flaky and, under the CI matrix, receives
+# so many simultaneous requests that it returns 500s. Running an httpbin-compatible
+# server locally removes that external dependency.
+#
+# The `http_request` resource issues the HTTP request from the itamae process
+# itself (`Net::HTTP`), so the reachable URL differs per backend:
+#   - docker backend: itamae runs on the host    -> host_url    (published port)
+#   - local  backend: itamae runs in a container -> NETWORK_URL (shared network)
+# The container therefore exposes both a published loopback port and a shared network.
+module HttpbinServer
+  IMAGE     = 'mccutchen/go-httpbin:2.24.0'
+  NETWORK   = 'itamae-test'
+  CONTAINER = 'httpbin'
+  PORT      = 8080 # container port; also the port in NETWORK_URL
+  NETWORK_URL = "http://#{CONTAINER}:#{PORT}".freeze # reachable from a container on NETWORK
+
+  module_function
+
+  # Host port to publish go-httpbin on. Overridable so local runs can avoid a
+  # port already in use on the host (CI runners always have the default free).
+  def host_port
+    ENV.fetch('HTTPBIN_HOST_PORT', PORT.to_s)
+  end
+
+  # URL reachable from the itamae host (docker backend). Kept in sync with the
+  # recipe default in spec/integration/recipes/*.rb.
+  def host_url
+    "http://127.0.0.1:#{host_port}"
+  end
+
+  def start
+    create_network
+    remove_container # drop any stale container from a previous run
+    run! 'docker', 'run', '-d', '--name', CONTAINER,
+         '--network', NETWORK,
+         '-p', "127.0.0.1:#{host_port}:#{PORT}",
+         IMAGE
+  end
+
+  def stop
+    remove_container
+    quiet 'docker', 'network', 'rm', NETWORK
+  end
+
+  def create_network
+    return if system('docker', 'network', 'inspect', NETWORK, out: File::NULL, err: File::NULL)
+    run! 'docker', 'network', 'create', NETWORK
+  end
+
+  def remove_container
+    quiet 'docker', 'rm', '-f', CONTAINER
+  end
+
+  def run!(*cmd)
+    system(*cmd) or raise "command failed: #{cmd.join(' ')}"
+  end
+
+  def quiet(*cmd)
+    system(*cmd, out: File::NULL, err: File::NULL)
+  end
+end

--- a/tasks/httpbin_server.rb
+++ b/tasks/httpbin_server.rb
@@ -10,7 +10,7 @@
 #   - local  backend: itamae runs in a container -> NETWORK_URL (shared network)
 # The container therefore exposes both a published loopback port and a shared network.
 module HttpbinServer
-  IMAGE     = 'mccutchen/go-httpbin:2.24.0'
+  IMAGE     = 'ghcr.io/mccutchen/go-httpbin:2.24.0'
   NETWORK   = 'itamae-test'
   CONTAINER = 'httpbin'
   PORT      = 8080 # container port; also the port in NETWORK_URL

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -10,22 +10,27 @@ namespace 'spec:integration:local' do
       next
     end
 
-    IntegrationLocalSpecRunner.new(
-      [
+    HttpbinServer.start
+    ENV['HTTPBIN_URL'] = HttpbinServer::NETWORK_URL
+    begin
+      IntegrationLocalSpecRunner.new(
         [
-          "spec/integration/recipes/default.rb",
-          "spec/integration/recipes/default2.rb",
-          "spec/integration/recipes/redefine.rb",
-          "spec/integration/recipes/local.rb",
+          [
+            "spec/integration/recipes/default.rb",
+            "spec/integration/recipes/default2.rb",
+            "spec/integration/recipes/redefine.rb",
+            "spec/integration/recipes/local.rb",
+          ],
+          [
+            "--dry-run",
+            "spec/integration/recipes/dry_run.rb",
+          ],
         ],
-        [
-          "--dry-run",
-          "spec/integration/recipes/dry_run.rb",
-        ],
-      ],
-      ['spec/integration/default_spec.rb']
-    ).run
-    
+        ['spec/integration/default_spec.rb']
+      ).run
+    ensure
+      HttpbinServer.stop
+    end
   end
 
   desc 'Run integration test for ordinary user with `itamae local`'
@@ -36,23 +41,29 @@ namespace 'spec:integration:local' do
       next
     end
 
-    runner = IntegrationLocalSpecRunner.new(
-      [
+    HttpbinServer.start
+    ENV['HTTPBIN_URL'] = HttpbinServer::NETWORK_URL
+    begin
+      runner = IntegrationLocalSpecRunner.new(
         [
-          "--dry-run",
-          "spec/integration/recipes/ordinary_user.rb",
+          [
+            "--dry-run",
+            "spec/integration/recipes/ordinary_user.rb",
+          ],
+          [
+            "spec/integration/recipes/ordinary_user.rb"
+          ],
         ],
-        [
-          "spec/integration/recipes/ordinary_user.rb"
-        ],
-      ],
-      ['spec/integration/ordinary_user_spec.rb'],
-      user: 'ordinary_san'
-    )
-    runner.docker_exec 'useradd', 'ordinary_san', '-p', '*'
-    runner.docker_exec 'useradd', 'itamae', '-p', '*', '--create-home'
-    runner.docker_exec 'sh', '-c', 'echo "ordinary_san ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers'
-    runner.run
+        ['spec/integration/ordinary_user_spec.rb'],
+        user: 'ordinary_san'
+      )
+      runner.docker_exec 'useradd', 'ordinary_san', '-p', '*'
+      runner.docker_exec 'useradd', 'itamae', '-p', '*', '--create-home'
+      runner.docker_exec 'sh', '-c', 'echo "ordinary_san ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers'
+      runner.run
+    ensure
+      HttpbinServer.stop
+    end
   end
 end
 
@@ -78,7 +89,7 @@ class IntegrationLocalSpecRunner
 
   def docker_run
     mount_dir = Pathname(__dir__).join('../').to_s
-    sh 'docker', 'run', '--env', 'SKIP_HTTP_REQUEST_TEST', '--privileged', '-d', '--name', CONTAINER_NAME, '-v', "#{mount_dir}:/itamae", "ruby:#{@ruby_version}", 'sleep', '1d'
+    sh 'docker', 'run', '--env', 'SKIP_HTTP_REQUEST_TEST', '--env', 'HTTPBIN_URL', '--network', HttpbinServer::NETWORK, '--privileged', '-d', '--name', CONTAINER_NAME, '-v', "#{mount_dir}:/itamae", "ruby:#{@ruby_version}", 'sleep', '1d'
   end
 
   def prepare
@@ -115,6 +126,6 @@ class IntegrationLocalSpecRunner
   end
 
   def docker_exec(*cmd, options: [])
-    sh 'docker', 'exec', '--env', 'LANG=en_US.utf8', '--env', 'SKIP_HTTP_REQUEST_TEST', *options, CONTAINER_NAME, *cmd
+    sh 'docker', 'exec', '--env', 'LANG=en_US.utf8', '--env', 'SKIP_HTTP_REQUEST_TEST', '--env', 'HTTPBIN_URL', *options, CONTAINER_NAME, *cmd
   end
 end

--- a/tasks/integration_local_spec.rb
+++ b/tasks/integration_local_spec.rb
@@ -89,7 +89,7 @@ class IntegrationLocalSpecRunner
 
   def docker_run
     mount_dir = Pathname(__dir__).join('../').to_s
-    sh 'docker', 'run', '--env', 'SKIP_HTTP_REQUEST_TEST', '--env', 'HTTPBIN_URL', '--network', HttpbinServer::NETWORK, '--privileged', '-d', '--name', CONTAINER_NAME, '-v', "#{mount_dir}:/itamae", "ruby:#{@ruby_version}", 'sleep', '1d'
+    sh 'docker', 'run', '--env', 'HTTPBIN_URL', '--network', HttpbinServer::NETWORK, '--privileged', '-d', '--name', CONTAINER_NAME, '-v', "#{mount_dir}:/itamae", "ruby:#{@ruby_version}", 'sleep', '1d'
   end
 
   def prepare
@@ -126,6 +126,6 @@ class IntegrationLocalSpecRunner
   end
 
   def docker_exec(*cmd, options: [])
-    sh 'docker', 'exec', '--env', 'LANG=en_US.utf8', '--env', 'SKIP_HTTP_REQUEST_TEST', '--env', 'HTTPBIN_URL', *options, CONTAINER_NAME, *cmd
+    sh 'docker', 'exec', '--env', 'LANG=en_US.utf8', '--env', 'HTTPBIN_URL', *options, CONTAINER_NAME, *cmd
   end
 end


### PR DESCRIPTION
## Summary

The `http_request` integration tests currently talk to the public
`httpbin.org` service. That service is flaky and, under the CI matrix,
receives enough simultaneous requests that it returns 500s. As a workaround
the suite forced `skip_http_request_test` to `true` across most of the matrix.

This PR replaces the external dependency with a locally managed
[`mccutchen/go-httpbin`](https://github.com/mccutchen/go-httpbin) container,
so the tests no longer depend on an external service and the skip switch can be
removed entirely.

## Changes

- Add a small module that manages a local `go-httpbin` container for the
  integration tests. The image is pulled from GHCR to avoid Docker Hub's
  anonymous pull rate limits in CI.
- Start/stop the server around both the docker and local integration runs
  (Rakefile wiring, workflow steps, and the local spec runner). The target is
  resolved from `HTTPBIN_URL`, defaulting to the local server, and the
  container network is shared with the local backend's container.
- Adjust the specs for go-httpbin's response format: send an explicit
  `Content-Type` on form-encoded POST/PUT requests so the body is parsed, and
  loosen the matchers for go-httpbin's array-valued query/header echoes.
- Drop the `skip_http_request_test` CI throttle now that the tests no longer
  hammer a shared public service.
- Remove the now-unreachable `SKIP_HTTP_REQUEST_TEST` guards from the recipes
  and the specs, and stop propagating the variable through `docker run` /
  `docker exec`.

## Notes for reviewers

Most of the recipe diff is reindentation from dropping the `unless` wrapper.
Reviewing with `?w=1` (whitespace ignored) makes it much smaller.
