### PR TITLE
Add workflow_dispatch trigger to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
       - reopened
   schedule:
     - cron: "0 0 * * 5" # JST 9:00 (Fri)
+  workflow_dispatch:
 
 jobs:
   test_main:


### PR DESCRIPTION
## Summary

The `test` workflow currently runs only on `push` to `master`, `pull_request`,
and a weekly `schedule`, so there is no way to run the unit and integration
tests manually.

Adding `workflow_dispatch` lets maintainers and contributors trigger the full
test suite on demand for any chosen branch, either from the Actions UI or via
the `gh` CLI (`gh workflow run`), without having to push a commit or open a
pull request. This is helpful when validating changes in environments where
the tests cannot be run locally.

For example, in cloud-based coding environments such as Claude Code Web, the
integration tests cannot be executed locally. Since these environments are
typically terminal-centric rather than browser-based, being able to trigger
the tests with the `gh` CLI is especially convenient there.

## Changes

- Add `workflow_dispatch:` to the `on:` triggers in
  `.github/workflows/test.yml`.
