### PR TITLE
Pull Docker Hub images through a mirror in CI

### DIFF
--- a/.github/workflows/docker-daemon.json
+++ b/.github/workflows/docker-daemon.json
@@ -1,0 +1,3 @@
+{
+  "registry-mirrors": ["https://mirror.gcr.io"]
+}

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -58,6 +58,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Pull Docker Hub images through mirror.gcr.io
+        run: |
+          sudo cp .github/workflows/docker-daemon.json /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ${{ inputs.ruby }}
@@ -111,6 +116,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Pull Docker Hub images through mirror.gcr.io
+        run: |
+          sudo cp .github/workflows/docker-daemon.json /etc/docker/daemon.json
+          sudo systemctl restart docker
 
       - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:


### PR DESCRIPTION
The integration jobs let `docker run` pull the test images implicitly from Docker Hub. When Docker Hub is unreachable, the job fails before any test runs:

    docker: Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded

This is a connection timeout, not a rate limit, and it happens intermittently. Pulls from ghcr.io in the same jobs succeed, so the problem is specific to Docker Hub.

This PR configures a Docker Hub mirror in GitHub Actions. The `integration-docker` and `integration-local` jobs copy the checked-in `.github/workflows/docker-daemon.json` over `/etc/docker/daemon.json` and restart the Docker daemon, following:
https://docs.cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images

Notes:

- The daemon pulls docker.io images from the mirror first. If the mirror cannot serve an image, it falls back to Docker Hub automatically.
- The setting applies only to docker.io images, so the go-httpbin image from ghcr.io is not affected.
- It also works for implicit pulls by `docker run`, so no test helper changes are needed.
