### PR TITLE
Add --docker-exec-timeout option to the docker backend

### DIFF
--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -45,6 +45,9 @@ jobs:
   integration-docker:
     runs-on: ubuntu-latest
 
+    # NOTE: --docker-exec-timeout raises the per-command timeout, so bound the job instead
+    timeout-minutes: 30
+
     strategy:
       fail-fast: false
 

--- a/Rakefile
+++ b/Rakefile
@@ -63,6 +63,7 @@ namespace :spec do
           cmd << "--container" << container_name
           cmd << "--tag" << "itamae:latest"
           cmd << "--tmp-dir" << (ENV['ITAMAE_TMP_DIR'] || '/tmp/itamae_tmp')
+          cmd << "--docker-exec-timeout" << (ENV['ITAMAE_DOCKER_EXEC_TIMEOUT'] || '600')
           cmd += suite
 
           p cmd

--- a/lib/itamae/backend.rb
+++ b/lib/itamae/backend.rb
@@ -321,7 +321,18 @@ module Itamae
           docker_container: @options[:container],
           shell: @options[:shell],
           docker_container_create_options: @options[:docker_container_create_options],
+          docker_container_exec_options: docker_container_exec_options,
         )
+      end
+
+      # docker-api treats `wait` as the read timeout of the exec API call, which
+      # limits how long a command may produce no output, not its total runtime.
+      # Without it, Excon's 60 seconds default applies.
+      def docker_container_exec_options
+        timeout = @options[:docker_exec_timeout]
+        return nil unless timeout
+
+        {wait: timeout}
       end
     end
   end

--- a/lib/itamae/cli.rb
+++ b/lib/itamae/cli.rb
@@ -78,6 +78,7 @@ module Itamae
     option :container, type: :string, desc: "This option or 'image' option is required."
     option :tls_verify_peer, type: :boolean, default: true
     option :tag, type: :string, desc: 'Tag name of created docker image.'
+    option :docker_exec_timeout, type: :numeric, desc: 'Seconds to wait for output from a command running in the container. (default: 60)'
     def docker(*recipe_files)
       if recipe_files.empty?
         raise "Please specify recipe files."

--- a/spec/unit/lib/itamae/backend_spec.rb
+++ b/spec/unit/lib/itamae/backend_spec.rb
@@ -111,5 +111,26 @@ EOF
         end
       end
     end
+
+    describe Docker do
+      describe "#docker_container_exec_options" do
+        subject { docker.send(:docker_container_exec_options) }
+
+        # Creating the specinfra backend would talk to the Docker daemon
+        before { allow_any_instance_of(described_class).to receive(:create_specinfra_backend) }
+
+        let!(:docker) { described_class.new(options) }
+
+        context "without docker_exec_timeout option" do
+          let(:options) { {container: 'itamae'} }
+          it { is_expected.to eq(nil) }
+        end
+
+        context "with docker_exec_timeout option" do
+          let(:options) { {container: 'itamae', docker_exec_timeout: 600} }
+          it { is_expected.to eq({wait: 600}) }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
`itamae docker` aborts with `Docker::Error::TimeoutError` when a command produces no output for 60 seconds.

docker-api sets a read timeout on the exec API call only when a `wait` option is given (`Docker::Exec#start!`); otherwise Excon's 60 seconds default applies. That timeout bounds the gap between reads, not the total runtime of the command, so anything that stays quiet for a minute — `apt-get` against a slow mirror, a compilation, a large download — kills the run even though it would have succeeded.

`Specinfra::Backend::Docker#docker_run!` merges `docker_container_exec_options` into the `exec` call, which is where `wait` would come from, but itamae only ever passed `docker_container_create_options` down to specinfra, so the setting was unreachable.

This adds `--docker-exec-timeout SECONDS` to the `docker` subcommand and translates it into `docker_container_exec_options`. Leaving it unset keeps the current 60 seconds behaviour, so nothing changes for existing users.

Notes:

- The backend returns `nil` rather than an empty hash when the option is absent. specinfra resolves the setting as `@config[key] || Specinfra.configuration.send(key)`, and an empty hash is truthy enough to shadow that fallback.
- The integration tests pass `--docker-exec-timeout 600`, overridable through `ITAMAE_DOCKER_EXEC_TIMEOUT`. `integration-docker` also gained `timeout-minutes`, since a single command may now run far longer before it gives up.

Verification, against a container provisioned with `execute 'sleep 90'`:

| | result |
| --- | --- |
| without the option | `Docker::Error::TimeoutError` after 60s |
| `--docker-exec-timeout 120` | succeeds after 90s |

`rake spec:unit` and `rake spec:integration:docker` pass locally, and the full CI matrix is green on this branch.

This touches `.github/workflows/test_main.yml`, which #444 also touches. The two changes are in different places within the file and merge cleanly in either order.